### PR TITLE
Add attempts to restart deamons if they die

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ pika = "*"
 structlog = "*"
 pgpy = "*"
 paramiko = "*"
+retrying = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "45ca6b32b88962b7c41d08b73a4468206e83ba3dd4568ff259534803273f0b51"
+            "sha256": "4e822abe836927b4d072b827c87f5fe99d7c46cc4691794266910fb5448d8a0c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -115,11 +115,11 @@
         },
         "pika": {
             "hashes": [
-                "sha256:0c50285f00a8b4816f2c9a44469107d9e738ba3a90386f14b625d8cceef4f6ae",
-                "sha256:5ba83d3daffccb92788d24facdab62a3db6aa03b8a6d709b03dc792d35c0dfe8"
+                "sha256:4e1a1a6585a41b2341992ec32aadb7a919d649eb82904fd8e4a4e0871c8cf3af",
+                "sha256:9fa76ba4b65034b878b2b8de90ff8660a59d925b087c5bb88f8fdbb4b64a1dbf"
             ],
             "index": "pypi",
-            "version": "==1.0.1"
+            "version": "==1.1.0"
         },
         "pyasn1": {
             "hashes": [
@@ -157,6 +157,13 @@
                 "sha256:f67814c38162f4deb31f68d590771a29d5ae3b1bd64b75cf232308e5c74777e0"
             ],
             "version": "==1.3.0"
+        },
+        "retrying": {
+            "hashes": [
+                "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"
+            ],
+            "index": "pypi",
+            "version": "==1.3.3"
         },
         "singledispatch": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Run with
 ```bash
 make unit_tests
 ```
-Note that you may see some stray error logs in the unit test output, this is a bug with pytest not fully suppressing all output from subprocesses and can safely be ignored if the tests are passing
-
 This will also lint and check dependency package safety
 
 ### Integration tests

--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -70,7 +70,7 @@ def start_file_sender(readiness_queue):
     logger.info('Started file sender')
     while True:
         check_partial_files(Config.PARTIAL_FILES_DIRECTORY)
-        sleep(2)
+        sleep(Config.FILE_POLLING_DELAY_SECONDS)
 
 
 def copy_files_to_sftp(file_paths: Collection[Path], remote_directory):

--- a/app/readiness.py
+++ b/app/readiness.py
@@ -6,17 +6,24 @@ from structlog import wrap_logger
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-class ReadinessFile:
+class Readiness:
     def __init__(self, readiness_file: Path):
         self.readiness_file = readiness_file
 
     def __enter__(self):
+        self.show_ready()
+        return self
+
+    def __exit__(self, *args):
+        self.show_unready()
+
+    def show_ready(self):
         logger.debug('Creating readiness file', readiness_file_path=str(self.readiness_file))
         self.readiness_file.touch()
 
-    def __exit__(self, *args):
+    def show_unready(self):
         logger.debug('Removing readiness file', readiness_file_path=str(self.readiness_file))
         try:
             self.readiness_file.unlink()
         except FileNotFoundError:
-            logger.error('Readiness file not found on exit', readiness_file_path=str(self.readiness_file))
+            logger.debug('Readiness file not found on exit', health_file_path=str(self.readiness_file))

--- a/app/readiness.py
+++ b/app/readiness.py
@@ -26,4 +26,4 @@ class Readiness:
         try:
             self.readiness_file.unlink()
         except FileNotFoundError:
-            logger.debug('Readiness file not found on exit', health_file_path=str(self.readiness_file))
+            logger.debug('Readiness file not found', health_file_path=str(self.readiness_file))

--- a/app/readiness.py
+++ b/app/readiness.py
@@ -26,4 +26,4 @@ class Readiness:
         try:
             self.readiness_file.unlink()
         except FileNotFoundError:
-            logger.debug('Readiness file not found', health_file_path=str(self.readiness_file))
+            logger.debug('Readiness file not found', readiness_file_path=str(self.readiness_file))

--- a/app/readiness_file.py
+++ b/app/readiness_file.py
@@ -11,7 +11,7 @@ class ReadinessFile:
         self.readiness_file = readiness_file
 
     def __enter__(self):
-        logger.debug('Creating readiness files', readiness_file_path=str(self.readiness_file))
+        logger.debug('Creating readiness file', readiness_file_path=str(self.readiness_file))
         self.readiness_file.touch()
 
     def __exit__(self, *args):

--- a/app/readiness_file.py
+++ b/app/readiness_file.py
@@ -11,8 +11,8 @@ class ReadinessFile:
         self.readiness_file = readiness_file
 
     def __enter__(self):
-        logger.debug('Creating readiness file', readiness_file_path=str(self.readiness_file))
-        open(self.readiness_file, 'w').close()
+        logger.debug('Creating readiness files', readiness_file_path=str(self.readiness_file))
+        self.readiness_file.touch()
 
     def __exit__(self, *args):
         logger.debug('Removing readiness file', readiness_file_path=str(self.readiness_file))

--- a/app/run_daemons.py
+++ b/app/run_daemons.py
@@ -49,4 +49,3 @@ def run_in_daemon(target, name, process_manager, timeout=3) -> multiprocessing.P
 @retry(wait_exponential_multiplier=1000, wait_exponential_max=20000, stop_max_attempt_number=10)
 def retry_run_daemon(target, name, process_manager, timeout=3):
     return run_in_daemon(target, name, process_manager, timeout=timeout)
-

--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ class Config:
 
     PARTIAL_FILES_DIRECTORY = Path(os.getenv('PARTIAL_FILES_DIRECTORY', 'partial_files/'))
     ENCRYPTED_FILES_DIRECTORY = Path(os.getenv('ENCRYPTED_FILES_DIRECTORY', 'encrypted_files/'))
+    FILE_POLLING_DELAY_SECONDS = int(os.getenv('FILE_POLLING_DELAY_SECONDS', 10))
 
     READINESS_FILE_PATH = Path(os.getenv('READINESS_FILE_PATH', 'print-file-service-ready'))
 
@@ -62,6 +63,8 @@ class DevConfig(Config):
     RABBIT_USERNAME = os.getenv('RABBIT_USERNAME', 'guest')
     RABBIT_PASSWORD = os.getenv('RABBIT_PASSWORD', 'guest')
 
+    FILE_SENDER_POLLING_DELAY = int(os.getenv('FILE_POLLING_DELAY_SECONDS', 1))
+
     SFTP_HOST = os.getenv('SFTP_HOST', 'localhost')
     SFTP_PORT = os.getenv('SFTP_PORT', '122')
     SFTP_USERNAME = os.getenv('SFTP_USERNAME', 'centos')
@@ -69,6 +72,7 @@ class DevConfig(Config):
     SFTP_PASSPHRASE = os.getenv('SFTP_PASSPHRASE', 'secret')
     SFTP_PPO_DIRECTORY = os.getenv('SFTP_PPO_DIRECTORY', 'ppo_dev/print_services/')
     SFTP_QM_DIRECTORY = os.getenv('SFTP_QM_DIRECTORY', 'qmprint_dev/print_services/')
+
     OUR_PUBLIC_KEY_PATH = Path(os.getenv('OUR_PUBLIC_KEY_PATH') or Path(__file__).parent.joinpath('dummy_keys')
                                .joinpath('our_dummy_public.asc'))
     QM_SUPPLIER_PUBLIC_KEY_PATH = Path(

--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ class DevConfig(Config):
     RABBIT_USERNAME = os.getenv('RABBIT_USERNAME', 'guest')
     RABBIT_PASSWORD = os.getenv('RABBIT_PASSWORD', 'guest')
 
-    FILE_SENDER_POLLING_DELAY = int(os.getenv('FILE_POLLING_DELAY_SECONDS', 1))
+    FILE_POLLING_DELAY_SECONDS = int(os.getenv('FILE_POLLING_DELAY_SECONDS', 1))
 
     SFTP_HOST = os.getenv('SFTP_HOST', 'localhost')
     SFTP_PORT = os.getenv('SFTP_PORT', '122')

--- a/test/unit_tests/app/test_readiness.py
+++ b/test/unit_tests/app/test_readiness.py
@@ -3,25 +3,25 @@ from pathlib import Path
 
 import pytest
 
-from app.readiness_file import ReadinessFile
+from app.readiness import Readiness
 
 
 def test_readiness_file_is_present_while_in_context(readiness_file_path):
-    with ReadinessFile(readiness_file_path):
-        assert readiness_file_path.exists(), 'Readiness file not found within readiness context'
+    with Readiness(readiness_file_path):
+        assert readiness_file_path.exists(), 'readiness file not found within readiness context'
 
 
 def test_readiness_file_is_not_present_after_exiting_context(readiness_file_path):
-    with ReadinessFile(readiness_file_path):
+    with Readiness(readiness_file_path):
         pass
-    assert not readiness_file_path.exists(), 'Readiness file was still present after exiting context'
+    assert not readiness_file_path.exists(), 'readiness file was still present after exiting context'
 
 
 def test_readiness_file_is_not_present_after_uncaught_exception_in_context(readiness_file_path):
     with pytest.raises(Exception):
-        with ReadinessFile(readiness_file_path):
+        with Readiness(readiness_file_path):
             raise Exception
-    assert not readiness_file_path.exists(), 'Readiness file was still present after uncaught exception in context'
+    assert not readiness_file_path.exists(), 'readiness file was still present after uncaught exception in context'
 
 
 @pytest.fixture

--- a/test/unit_tests/app/test_readiness.py
+++ b/test/unit_tests/app/test_readiness.py
@@ -8,20 +8,20 @@ from app.readiness import Readiness
 
 def test_readiness_file_is_present_while_in_context(readiness_file_path):
     with Readiness(readiness_file_path):
-        assert readiness_file_path.exists(), 'readiness file not found within readiness context'
+        assert readiness_file_path.exists(), 'Readiness file not found within readiness context'
 
 
 def test_readiness_file_is_not_present_after_exiting_context(readiness_file_path):
     with Readiness(readiness_file_path):
         pass
-    assert not readiness_file_path.exists(), 'readiness file was still present after exiting context'
+    assert not readiness_file_path.exists(), 'Readiness file was still present after exiting context'
 
 
 def test_readiness_file_is_not_present_after_uncaught_exception_in_context(readiness_file_path):
     with pytest.raises(Exception):
         with Readiness(readiness_file_path):
             raise Exception
-    assert not readiness_file_path.exists(), 'readiness file was still present after uncaught exception in context'
+    assert not readiness_file_path.exists(), 'Readiness file was still present after uncaught exception in context'
 
 
 @pytest.fixture

--- a/test/unit_tests/app/test_run_daemons.py
+++ b/test/unit_tests/app/test_run_daemons.py
@@ -1,5 +1,4 @@
 import queue
-from time import sleep
 from unittest.mock import patch, ANY
 
 import pytest
@@ -86,10 +85,8 @@ def test_file_sender_restarts_on_error(patched_retry_run_daemon, patched_process
     patched_retry_run_daemon.assert_called_once_with(ANY, 'file-sender', ANY)
 
 
-def raise_exception(*_, **kwargs):
-    sleep(kwargs['delay'])
+def raise_exception(*_, **_kwargs):
     raise Exception('An error happened')
-    # pass
 
 
 def raise_queue_empty(*_args, **_kwargs):

--- a/test/unit_tests/app/test_run_daemons.py
+++ b/test/unit_tests/app/test_run_daemons.py
@@ -23,25 +23,5 @@ def test_rabbit_connection_failure_blocks_app_startup(patched_rabbit_context, _p
         assert str(err) == 'Error starting daemon: [message-listener]'
 
 
-@patch('app.file_sender.sftp.SftpUtility')
-@patch('app.message_listener.RabbitContext')
-def test_message_listener_daemon_dying_kills_app(patched_rabbit_context, _patched_sftp_utility):
-    patched_rabbit_context.return_value.__enter__.return_value.channel.start_consuming.side_effect = raise_exception
-    with pytest.raises(RuntimeError) as err:
-        run_daemons()
-        assert str(err) == 'Message listener died'
-
-
-@patch('app.file_sender.check_partial_files')
-@patch('app.file_sender.sftp.SftpUtility')
-@patch('app.message_listener.RabbitContext')
-def test_file_sender_daemon_dying_kills_app(_patched_rabbit_context, _patched_sftp_utility,
-                                            patched_check_partial_files):
-    patched_check_partial_files.side_effect = raise_exception
-    with pytest.raises(RuntimeError) as err:
-        run_daemons()
-        assert str(err) == 'File sender died'
-
-
 def raise_exception(*_, **_kwargs):
     raise Exception('An error happened')

--- a/test/unit_tests/app/test_run_daemons.py
+++ b/test/unit_tests/app/test_run_daemons.py
@@ -1,27 +1,96 @@
-from unittest.mock import patch
+import queue
+from time import sleep
+from unittest.mock import patch, ANY
 
 import pytest
 
 from app.run_daemons import DaemonStartupError, run_daemons
 
 
-@patch('app.file_sender.sftp.SftpUtility')
-@patch('app.message_listener.RabbitContext')
-def test_sftp_failure_blocks_app_startup(_patched_sftp_utility, patched_sftp_utility):
-    patched_sftp_utility.side_effect = raise_exception
+@patch('app.run_daemons.multiprocessing.Process')
+@patch('app.run_daemons.multiprocessing.Manager')
+def test_sftp_failure_blocks_app_startup(patched_manager, _patched_process):
+    # Given
+    # Message listener starts first so fail on the second start
+    call_count = 0
+
+    def first_true_then_raise_queue_empty(*_args, **_kwargs):
+        nonlocal call_count
+        if call_count == 0:
+            call_count += 1
+            return True
+        else:
+            raise queue.Empty
+
+    patched_manager.return_value.Queue.return_value.get.side_effect = first_true_then_raise_queue_empty
+
+    # When
     with pytest.raises(DaemonStartupError) as err:
         run_daemons()
-        assert str(err) == 'Error starting daemon: [file-sender]'
+
+    # Then
+    assert str(err.value) == 'Error starting daemon: [file-sender]'
 
 
-@patch('app.file_sender.sftp.SftpUtility')
-@patch('app.message_listener.RabbitContext')
-def test_rabbit_connection_failure_blocks_app_startup(patched_rabbit_context, _patched_sftp_utility):
-    patched_rabbit_context.side_effect = raise_exception
+@patch('app.run_daemons.multiprocessing.Process')
+@patch('app.run_daemons.multiprocessing.Manager')
+def test_rabbit_connection_failure_blocks_app_startup(patched_manager, _patched_process):
+    # Given
+    patched_manager.return_value.Queue.return_value.get.side_effect = raise_queue_empty
+
+    # When
     with pytest.raises(DaemonStartupError) as err:
         run_daemons()
-        assert str(err) == 'Error starting daemon: [message-listener]'
+
+    # Then
+    assert str(err.value) == 'Error starting daemon: [message-listener]'
 
 
-def raise_exception(*_, **_kwargs):
+@patch('app.run_daemons.multiprocessing.Manager')
+@patch('app.run_daemons.multiprocessing.Process')
+@patch('app.run_daemons.retry_run_daemon')
+def test_message_listener_restarts_on_error(patched_retry_run_daemon, patched_process, patched_manager):
+    # Given
+    patched_manager.return_value.Queue.return_value.get.return_value = True
+    patched_process.return_value.is_alive.return_value = False
+
+    # Raise an exception to break out of the infinite loop
+    patched_retry_run_daemon.side_effect = raise_exception
+
+    # When
+    with pytest.raises(Exception):
+        run_daemons()
+
+    # Then
+    patched_retry_run_daemon.assert_called_once_with(ANY, 'message-listener', ANY)
+
+
+@patch('app.run_daemons.multiprocessing.Manager')
+@patch('app.run_daemons.multiprocessing.Process')
+@patch('app.run_daemons.retry_run_daemon')
+def test_file_sender_restarts_on_error(patched_retry_run_daemon, patched_process, patched_manager):
+    # Given
+    patched_manager.return_value.Queue.return_value.get.return_value = True
+
+    # is_alive is called for the message listener first, so return False on the second call
+    patched_process.return_value.is_alive.side_effect = (True, False)
+
+    # Raise an exception to break out of the infinite loop
+    patched_retry_run_daemon.side_effect = raise_exception
+
+    # When
+    with pytest.raises(Exception):
+        run_daemons()
+
+    # Then
+    patched_retry_run_daemon.assert_called_once_with(ANY, 'file-sender', ANY)
+
+
+def raise_exception(*_, **kwargs):
+    sleep(kwargs['delay'])
     raise Exception('An error happened')
+    # pass
+
+
+def raise_queue_empty(*_args, **_kwargs):
+    raise queue.Empty


### PR DESCRIPTION
# Motivation and Context
Currently if one of the processes dies it immediately brings the whole service down with it, this PR adds attempts to restart the sub process daemons.

# What has changed
* Added attempts to restart the sub processes if they die

# How to test?
Run the service and do something to cause one of the components to error, e.g turn off the sftp then try to generate a print file. You should see the file sender die, then attempts to restart it exponentially backing off and if you bring the SFTP back up it should start the file sender successfully.

# Links
https://trello.com/c/vfM7zXqQ/974-spike-better-error-handling-in-print-file-service-1-day