### PR TITLE
Defect #969: QM Print File - coordinator_id

### DIFF
--- a/app/print_file_builder.py
+++ b/app/print_file_builder.py
@@ -23,7 +23,7 @@ QUESTIONNAIRE_TEMPLATE = ('uac',
                           'qid',
                           'uacWales',
                           'qidWales',
-                          'caseRef',
+                          'fieldCoordinatorId',
                           'title',
                           'forename',
                           'surname',
@@ -47,8 +47,7 @@ def generate_print_row(json_body: str, partial_file_path: Path):
         logger.error('No template found for action type', action_type=print_message.get('actionType'),
                      batch_id=print_message.get('batchId'))
         raise TemplateNotFoundError
-
-    append_print_row(print_message, template, partial_file_path, )
+    append_print_row(print_message, template, partial_file_path)
 
 
 def get_filename(print_message):

--- a/test/integration_tests/test_end_to_end.py
+++ b/test/integration_tests/test_end_to_end.py
@@ -35,6 +35,7 @@ ICHHQ_message_template = {
     'uacWales': "welsh_uac",
     'qidWales': "welsh_qid",
     "caseRef": "test_caseref",
+    "fieldCoordinatorId": "test_qm_coordinator_id",
     "title": "Mr",
     "forename": "Test",
     "surname": "McTest",
@@ -156,11 +157,11 @@ def test_ichhqe_files():
                                                                'dummy_qm_supplier_private_key.asc'),
         decryption_key_passphrase='supplier',
         expected=(
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n'
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n'
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n'))
 
 
@@ -190,11 +191,11 @@ def test_ichhqw_files():
                                                                'dummy_qm_supplier_private_key.asc'),
         decryption_key_passphrase='supplier',
         expected=(
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H2\n'
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H2\n'
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H2\n'))
 
 
@@ -224,11 +225,11 @@ def test_ichhqn_files():
                                                                'dummy_qm_supplier_private_key.asc'),
         decryption_key_passphrase='supplier',
         expected=(
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H4\n'
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H4\n'
-            'english_uac|english_qid|welsh_uac|welsh_qid|test_caseref|'
+            'english_uac|english_qid|welsh_uac|welsh_qid|test_qm_coordinator_id|'
             'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H4\n'))
 
 

--- a/test/unit_tests/app/test_print_file_builder.py
+++ b/test/unit_tests/app/test_print_file_builder.py
@@ -44,7 +44,8 @@ def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
         "qid": "test_qid",
         "uacWales": "test_wales_uac",
         "qidWales": "test_wales_qid",
-        "caseRef": "test_caseref",
+        "caseRef": "test_caseref",  # NB: ignored
+        "fieldCoordinatorId": "test_qm_coordinator_id",
         "title": "Mr",
         "forename": "Test",
         "surname": "McTest",
@@ -61,7 +62,7 @@ def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
     # Then
     generated_print_file = partial_files_directory.joinpath('ICHHQE.P_IC_H1.1.3')
     assert generated_print_file.read_text() == (
-        'test_uac|test_qid|test_wales_uac|test_wales_qid|test_caseref|'
+        'test_uac|test_qid|test_wales_uac|test_wales_qid|test_qm_coordinator_id|'
         'Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n')
 
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During WhiteLodge testing it was found the Questionnaire Management print files (E, W and NI) are currently holding the 'caseref' in the column that should contain 'coordinator_id'. 

coordinator_id is provided on the sample file, can range from 8 to 10 characters and is NOT mandatory

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

- Caseref removed from questionnaire type mapping
- Field coordinator ID added
- Updated expected tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

- `make build_and_test`
- Run against acceptance tests

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
- https://github.com/ONSdigital/census-rm-action-scheduler/pull/22
- https://github.com/ONSdigital/census-rm-acceptance-tests/pull/88
- [Trello card #969](https://trello.com/c/DxUlMxSc)

