### PR TITLE
create <filename>.csv.gpg files instead of <filename>.csv

### DIFF
--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -41,7 +41,7 @@ def process_complete_file(print_file: Path, pack_code):
 def encrypt_print_file(print_file, pack_code, supplier):
     encrypted_message = pgp_encrypt_message(print_file.read_text(), supplier)
     filename = f'{pack_code}_{datetime.utcnow().strftime("%Y-%m-%dT%H-%M-%S")}'
-    encrypted_print_file = Config.ENCRYPTED_FILES_DIRECTORY.joinpath(f'{filename}.csv')
+    encrypted_print_file = Config.ENCRYPTED_FILES_DIRECTORY.joinpath(f'{filename}.csv.gpg')
     logger.info('Writing encrypted file', file_name=encrypted_print_file.name)
     encrypted_print_file.write_text(encrypted_message)
     return encrypted_print_file, filename

--- a/test/integration_tests/test_end_to_end.py
+++ b/test/integration_tests/test_end_to_end.py
@@ -272,7 +272,7 @@ def get_print_and_manifest_filenames(sftp, remote_directory, pack_code, max_atte
     attempts = 0
     while attempts <= max_attempts:
         matched_print_files = [filename for filename in sftp.listdir(remote_directory)
-                               if fnmatch.fnmatch(filename, f'{pack_code}_*.csv')]
+                               if fnmatch.fnmatch(filename, f'{pack_code}_*.csv.gpg')]
         matched_manifest_files = [filename for filename in sftp.listdir(remote_directory)
                                   if fnmatch.fnmatch(filename, f'{pack_code}_*.manifest')]
         attempts += 1

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -47,8 +47,8 @@ def test_processing_complete_file_uploads_correct_files(cleanup_test_files):
     iso_mocked = mock_time.strftime("%Y-%m-%dT%H-%M-%S")
 
     assert put_sftp_call_kwargs[0]['local_path'] == str(
-        cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mocked}.csv'))
-    assert put_sftp_call_kwargs[0]['filename'] == f'P_IC_ICL1_{iso_mocked}.csv'
+        cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mocked}.csv.gpg'))
+    assert put_sftp_call_kwargs[0]['filename'] == f'P_IC_ICL1_{iso_mocked}.csv.gpg'
     assert put_sftp_call_kwargs[1]['local_path'] == str(
         cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mocked}.manifest'))
     assert put_sftp_call_kwargs[1]['filename'] == f'P_IC_ICL1_{iso_mocked}.manifest'


### PR DESCRIPTION
# Motivation and Context
the print file specification say we need to add a ".gpg" extensions for encrypted files

# What has changed
changes the "encrypt_print_file" function to add ".gpg" the end of the generated file

# How to test?
load a sample and execute any "print file action plans", you should see *.gpg files created on the sftp server

# Links
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/89