### PR TITLE
RMC-134 Large Print Questionnaires and Translation Booklet Fulfilment Requests

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -53,15 +53,6 @@ class PackCode(Enum):
     P_TB_TBURD1 = "P_TB_TBURD1"
     P_TB_TBVIE1 = "P_TB_TBVIE1"
     P_TB_TBYSH1 = "P_TB_TBYSH1"
-    UACHHT1 = "UACHHT1"
-    UACHHT2 = "UACHHT2"
-    UACHHT2W = "UACHHT2W"
-    UACHHT4 = "UACHHT4"
-    UACIT1 = "UACIT1"
-    UACIT2 = "UACIT2"
-    UACIT2W = "UACIT2W"
-    UACIT4 = "UACIT4"
-
 
 class Dataset(Enum):
     QM3_2 = 'QM3.2'

--- a/app/constants.py
+++ b/app/constants.py
@@ -9,6 +9,8 @@ class ActionType(Enum):
     ICHHQW = 'ICHHQW'
     ICHHQN = 'ICHHQN'
     P_OR_HX = 'P_OR_HX'
+    P_LP_HLX = 'P_LP_HLX'
+    P_TB_TBX = 'P_TB_TBX'
 
 
 class PackCode(Enum):
@@ -22,12 +24,50 @@ class PackCode(Enum):
     P_OR_H2 = 'P_OR_H2'
     P_OR_H2W = 'P_OR_H2W'
     P_OR_H4 = 'P_OR_H4'
+    P_LP_HL1 = "P_LP_HL1"
+    P_LP_HL2 = "P_LP_HL2"
+    P_LP_HL2W = "P_LP_HL2W"
+    P_LP_HL4 = "P_LP_HL4"
+    P_TB_TBARA1 = "P_TB_TBARA1"
+    P_TB_TBBEN1 = "P_TB_TBBEN1"
+    P_TB_TBCAN1 = "P_TB_TBCAN1"
+    P_TB_TBCAN4 = "P_TB_TBCAN4"
+    P_TB_TBFRE1 = "P_TB_TBFRE1"
+    P_TB_TBGUJ1 = "P_TB_TBGUJ1"
+    P_TB_TBGUR1 = "P_TB_TBGUR1"
+    P_TB_TBIRI4 = "P_TB_TBIRI4"
+    P_TB_TBITA1 = "P_TB_TBITA1"
+    P_TB_TBKUR1 = "P_TB_TBKUR1"
+    P_TB_TBLIT1 = "P_TB_TBLIT1"
+    T_PB_TBLIT4 = "T_PB_TBLIT4"
+    P_TB_TBMAN1 = "P_TB_TBMAN1"
+    P_TB_TBMAN4 = "P_TB_TBMAN4"
+    P_TB_TBPOL1 = "P_TB_TBPOL1"
+    P_TB_TBPOL4 = "P_TB_TBPOL4"
+    P_TB_TBPOR1 = "P_TB_TBPOR1"
+    P_TB_TBRUS1 = "P_TB_TBRUS1"
+    P_TB_TBSOM1 = "P_TB_TBSOM1"
+    P_TB_TBSPA1 = "P_TB_TBSPA1"
+    P_TB_TBTUR1 = "P_TB_TBTUR1"
+    P_TB_TBULS4 = "P_TB_TBULS4"
+    P_TB_TBURD1 = "P_TB_TBURD1"
+    P_TB_TBVIE1 = "P_TB_TBVIE1"
+    P_TB_TBYSH1 = "P_TB_TBYSH1"
+    UACHHT1 = "UACHHT1"
+    UACHHT2 = "UACHHT2"
+    UACHHT2W = "UACHHT2W"
+    UACHHT4 = "UACHHT4"
+    UACIT1 = "UACIT1"
+    UACIT2 = "UACIT2"
+    UACIT2W = "UACIT2W"
+    UACIT4 = "UACIT4"
 
 
 class Dataset(Enum):
     QM3_2 = 'QM3.2'
     QM3_4 = 'QM3.4'
     PPD1_1 = 'PPD1.1'
+    PPD1_3 = 'PPD1.3'
 
 
 class Supplier(Enum):

--- a/app/constants.py
+++ b/app/constants.py
@@ -54,6 +54,7 @@ class PackCode(Enum):
     P_TB_TBVIE1 = "P_TB_TBVIE1"
     P_TB_TBYSH1 = "P_TB_TBYSH1"
 
+
 class Dataset(Enum):
     QM3_2 = 'QM3.2'
     QM3_4 = 'QM3.4'

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -22,7 +22,7 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_TB_TBCAN4: 'Translation Booklet for Northern Ireland - Cantonese',
     PackCode.P_TB_TBFRE1: 'Translation Booklet for England & Wales - French',
     PackCode.P_TB_TBGUJ1: 'Translation Booklet for England & Wales - Gujarati',
-    PackCode.P_TB_TBGUR1: 'Translation Booklet for England & Wales - Panjabi – Gurmukhi	',
+    PackCode.P_TB_TBGUR1: 'Translation Booklet for England & Wales - Panjabi – Gurmukhi',
     PackCode.P_TB_TBIRI4: 'Translation Booklet for Northern Ireland - Irish',
     PackCode.P_TB_TBITA1: 'Translation Booklet for England & Wales - Italian',
     PackCode.P_TB_TBKUR1: 'Translation Booklet for England & Wales - Kurdish',
@@ -110,7 +110,7 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.ICHHQW: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
     ActionType.ICHHQN: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
     ActionType.P_OR_HX: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
-    ActionType.P_LP_HX: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_LP_HLX: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_TB_TBX: PrintTemplate.PPO_LETTER_TEMPLATE
 
 }

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -12,6 +12,36 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_OR_H2: 'Household Questionnaire for Wales (English)',
     PackCode.P_OR_H2W: 'Household Questionnaire for Wales (Welsh)',
     PackCode.P_OR_H4: 'Household Questionnaire for Northern Ireland (English)',
+    PackCode.P_LP_HL1: 'Household Questionnaire Large Print pack for England',
+    PackCode.P_LP_HL2: 'Household Questionnaire Large Print pack for Wales (English)',
+    PackCode.P_LP_HL2W: 'Household Questionnaire Large Print pack for Wales (Welsh)',
+    PackCode.P_LP_HL4: 'Household Questionnaire Large Print pack for Northern Ireland',
+    PackCode.P_TB_TBARA1: 'Translation Booklet for England & Wales - Arabic',
+    PackCode.P_TB_TBBEN1: 'Translation Booklet for England & Wales - Bengali',
+    PackCode.P_TB_TBCAN1: 'Translation Booklet for England & Wales - Cantonese',
+    PackCode.P_TB_TBCAN4: 'Translation Booklet for Northern Ireland - Cantonese',
+    PackCode.P_TB_TBFRE1: 'Translation Booklet for England & Wales - French',
+    PackCode.P_TB_TBGUJ1: 'Translation Booklet for England & Wales - Gujarati',
+    PackCode.P_TB_TBGUR1: 'Translation Booklet for England & Wales - Panjabi – Gurmukhi	',
+    PackCode.P_TB_TBIRI4: 'Translation Booklet for Northern Ireland - Irish',
+    PackCode.P_TB_TBITA1: 'Translation Booklet for England & Wales - Italian',
+    PackCode.P_TB_TBKUR1: 'Translation Booklet for England & Wales - Kurdish',
+    PackCode.P_TB_TBLIT1: 'Translation Booklet for England & Wales - Lithuanian',
+    PackCode.T_PB_TBLIT4: 'Translation Booklet for Northern Ireland - Lithuanian',
+    PackCode.P_TB_TBMAN1: 'Translation Booklet for England & Wales - Mandarin Chinese',
+    PackCode.P_TB_TBMAN4: 'Translation Booklet for Northern Ireland - Mandarin',
+    PackCode.P_TB_TBPOL1: 'Translation Booklet for England & Wales - Polish',
+    PackCode.P_TB_TBPOL4: 'Translation Booklet for Northern Ireland - Polish',
+    PackCode.P_TB_TBPOR1: 'Translation Booklet for England & Wales - Portuguese',
+    PackCode.P_TB_TBRUS1: 'Translation Booklet for England & Wales - Russian',
+    PackCode.P_TB_TBSOM1: 'Translation Booklet for England & Wales - Somali',
+    PackCode.P_TB_TBSPA1: 'Translation Booklet for England & Wales - Spanish',
+    PackCode.P_TB_TBTUR1: 'Translation Booklet for England & Wales - Turkish',
+    PackCode.P_TB_TBULS4: 'Translation Booklet for Northern Ireland - Ulster-Scots',
+    PackCode.P_TB_TBURD1: 'Translation Booklet for England & Wales - Urdu',
+    PackCode.P_TB_TBVIE1: 'Translation Booklet for England & Wales - Vietnamese',
+    PackCode.P_TB_TBYSH1: 'Translation Booklet for England & Wales - Yiddish',
+
 }
 
 PACK_CODE_TO_DATASET = {
@@ -25,12 +55,41 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_OR_H2: Dataset.QM3_4,
     PackCode.P_OR_H2W: Dataset.QM3_4,
     PackCode.P_OR_H4: Dataset.QM3_4,
+    PackCode.P_LP_HL1: Dataset.PPD1_3,
+    PackCode.P_LP_HL2: Dataset.PPD1_3,
+    PackCode.P_LP_HL2W: Dataset.PPD1_3,
+    PackCode.P_LP_HL4: Dataset.PPD1_3,
+    PackCode.P_TB_TBARA1: Dataset.PPD1_3,
+    PackCode.P_TB_TBBEN1: Dataset.PPD1_3,
+    PackCode.P_TB_TBCAN1: Dataset.PPD1_3,
+    PackCode.P_TB_TBCAN4: Dataset.PPD1_3,
+    PackCode.P_TB_TBFRE1: Dataset.PPD1_3,
+    PackCode.P_TB_TBGUJ1: Dataset.PPD1_3,
+    PackCode.P_TB_TBGUR1: Dataset.PPD1_3,
+    PackCode.P_TB_TBIRI4: Dataset.PPD1_3,
+    PackCode.P_TB_TBITA1: Dataset.PPD1_3,
+    PackCode.P_TB_TBKUR1: Dataset.PPD1_3,
+    PackCode.P_TB_TBLIT1: Dataset.PPD1_3,
+    PackCode.T_PB_TBLIT4: Dataset.PPD1_3,
+    PackCode.P_TB_TBMAN1: Dataset.PPD1_3,
+    PackCode.P_TB_TBMAN4: Dataset.PPD1_3,
+    PackCode.P_TB_TBPOL1: Dataset.PPD1_3,
+    PackCode.P_TB_TBPOL4: Dataset.PPD1_3,
+    PackCode.P_TB_TBPOR1: Dataset.PPD1_3,
+    PackCode.P_TB_TBRUS1: Dataset.PPD1_3,
+    PackCode.P_TB_TBSOM1: Dataset.PPD1_3,
+    PackCode.P_TB_TBSPA1: Dataset.PPD1_3,
+    PackCode.P_TB_TBTUR1: Dataset.PPD1_3,
+    PackCode.P_TB_TBULS4: Dataset.PPD1_3,
+    PackCode.P_TB_TBVIE1: Dataset.PPD1_3,
+    PackCode.P_TB_TBYSH1: Dataset.PPD1_3,
 }
 
 DATASET_TO_SUPPLIER = {
     Dataset.QM3_2: Supplier.QM,
     Dataset.QM3_4: Supplier.QM,
     Dataset.PPD1_1: Supplier.PPO,
+    Dataset.PPD1_3: Supplier.PPO
 }
 
 SUPPLIER_TO_SFTP_DIRECTORY = {
@@ -51,6 +110,9 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.ICHHQW: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
     ActionType.ICHHQN: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
     ActionType.P_OR_HX: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
+    ActionType.P_LP_HX: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_TB_TBX: PrintTemplate.PPO_LETTER_TEMPLATE
+
 }
 
 SUPPLIER_TO_PRINT_TEMPLATE = {

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -302,6 +302,58 @@ def test_P_OR_H4(sftp_client):
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H4\n'))
 
 
+def test_P_LP_HL1(sftp_client):
+    # Given
+    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'P_LP_HLX', 'P_LP_HL1')
+    send_action_messages(icl1e_messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_LP_HL1')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Household Questionnaire Large Print pack for England',
+                                    'dataset': 'PPD1.3'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_LP_HL1\n')
+
+
+def test_P_TB_TBPOL1(sftp_client):
+    # Given
+    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'P_TB_TBX', 'P_TB_TBPOL1', uac=False)
+    send_action_messages(icl1e_messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_TB_TBPOL1')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Translation Booklet for England & Wales - Polish',
+                                    'dataset': 'PPD1.3'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1\n')
+
+
 def test_our_decryption_key(sftp_client):
     # Given
     icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'ICL1E', 'P_IC_ICL1')

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -9,7 +9,7 @@ import pytest
 
 from config import TestConfig
 from test.integration_tests.utilities import build_test_messages, send_action_messages, ICL_message_template, \
-    ICHHQ_message_template, P_OR_message_template
+    ICHHQ_message_template, P_OR_message_template, PPD1_3_message_template
 
 
 def test_ICL1E(sftp_client):
@@ -304,7 +304,7 @@ def test_P_OR_H4(sftp_client):
 
 def test_P_LP_HL1(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'P_LP_HLX', 'P_LP_HL1', uac=False)
+    icl1e_messages, _ = build_test_messages(PPD1_3_message_template, 1, 'P_LP_HLX', 'P_LP_HL1', uac=False)
     send_action_messages(icl1e_messages)
 
     # When
@@ -325,12 +325,12 @@ def test_P_LP_HL1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_LP_HL1\n')
+        expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_LP_HL1\n')
 
 
 def test_P_TB_TBPOL1(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'P_TB_TBX', 'P_TB_TBPOL1', uac=False)
+    icl1e_messages, _ = build_test_messages(PPD1_3_message_template, 1, 'P_TB_TBX', 'P_TB_TBPOL1', uac=False)
     send_action_messages(icl1e_messages)
 
     # When
@@ -351,7 +351,7 @@ def test_P_TB_TBPOL1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1\n')
+        expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1\n')
 
 
 def test_our_decryption_key(sftp_client):

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -304,8 +304,8 @@ def test_P_OR_H4(sftp_client):
 
 def test_P_LP_HL1(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(PPD1_3_message_template, 1, 'P_LP_HLX', 'P_LP_HL1', uac=False)
-    send_action_messages(icl1e_messages)
+    messages, _ = build_test_messages(PPD1_3_message_template, 1, 'P_LP_HLX', 'P_LP_HL1', uac=False)
+    send_action_messages(messages)
 
     # When
     matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
@@ -330,8 +330,8 @@ def test_P_LP_HL1(sftp_client):
 
 def test_P_TB_TBPOL1(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(PPD1_3_message_template, 1, 'P_TB_TBX', 'P_TB_TBPOL1', uac=False)
-    send_action_messages(icl1e_messages)
+    messages, _ = build_test_messages(PPD1_3_message_template, 1, 'P_TB_TBX', 'P_TB_TBPOL1', uac=False)
+    send_action_messages(messages)
 
     # When
     matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -304,7 +304,7 @@ def test_P_OR_H4(sftp_client):
 
 def test_P_LP_HL1(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'P_LP_HLX', 'P_LP_HL1')
+    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'P_LP_HLX', 'P_LP_HL1', uac=False)
     send_action_messages(icl1e_messages)
 
     # When

--- a/test/integration_tests/utilities.py
+++ b/test/integration_tests/utilities.py
@@ -50,11 +50,7 @@ P_OR_message_template = {
 }
 
 
-def build_test_messages(message_template, quantity, action_type, pack_code):
-    messages = []
-    batch_id = str(uuid.uuid4())
-    for _ in range(quantity):
-        messages.append(message_template.copy())
+def build_messages_with_uac(message_template, action_type, quantity, pack_code, batch_id, messages):
     test_uac = 0
     for message in messages:
         message.update({'actionType': action_type,
@@ -67,6 +63,24 @@ def build_test_messages(message_template, quantity, action_type, pack_code):
             message['uacWales'] = str(test_uac)
             test_uac += 1
     return messages, batch_id
+
+
+def build_messages_no_uac(action_type, quantity, pack_code, batch_id, messages):
+    for message in messages:
+        message.update({'actionType': action_type,
+                        'batchQuantity': quantity,
+                        'packCode': pack_code,
+                        'batchId': batch_id})
+    return messages, batch_id
+
+
+def build_test_messages(message_template, quantity, action_type, pack_code, uac=True):
+    messages = []
+    batch_id = str(uuid.uuid4())
+    for _ in range(quantity):
+        messages.append(message_template.copy())
+    return build_messages_with_uac(message_template, action_type, quantity, pack_code, batch_id, messages) \
+        if uac else build_messages_no_uac(action_type, quantity, pack_code, batch_id, messages)
 
 
 def send_action_messages(message_dicts):

--- a/test/integration_tests/utilities.py
+++ b/test/integration_tests/utilities.py
@@ -16,6 +16,20 @@ ICL_message_template = {
     "postcode": "NPXXXX",
     "packCode": None
 }
+
+PPD1_3_message_template = {
+    "uac": None,
+    "caseRef": "test_caseref",
+    "title": "Mr",
+    "forename": "Test",
+    "surname": "McTest",
+    "addressLine1": "123 Fake Street",
+    "addressLine2": "Duffryn",
+    "townName": "Newport",
+    "postcode": "NPXXXX",
+    "packCode": None
+}
+
 ICHHQ_message_template = {
     "actionType": None,
     "batchId": None,


### PR DESCRIPTION
# Motivation and Context
For large print files and translation booklets, we needed to update the mappings so it could cope with the new pack codes coming in.

# What has changed
- Added new mappings for Supplementary Printed Materials(Large print files and translation booklets)
- Added integration tests to create print files using some of the new pack codes

# How to test?
- Run with [action scheduler branch](https://github.com/ONSdigital/census-rm-action-scheduler/pull/27/files) and [Acceptance tests](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/108)
- Run tests
- Run acceptance tests

# Links
[Trello](https://trello.com/c/yDd9LhBR/)