### PR TITLE
RMC-157 Scheduled Reminder Questionnaires

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -21,6 +21,11 @@ class ActionType(Enum):
     P_RL_2RL1_3a = 'P_RL_2RL1_3a'
     P_RL_2RL2B_3a = 'P_RL_2RL2B_3a'
 
+    # Reminder Questionnaires
+    P_QU_H1 = 'P_QU_H1'
+    P_QU_H2 = 'P_QU_H2'
+    P_QU_H4 = 'P_QU_H4'
+
     # On request questionnaire fulfilments
     P_OR_HX = 'P_OR_HX'
 
@@ -29,7 +34,6 @@ class ActionType(Enum):
 
     # Translation booklet fulfilments
     P_TB_TBX = 'P_TB_TBX'
-
 
 
 class PackCode(Enum):
@@ -51,6 +55,11 @@ class PackCode(Enum):
     P_RL_1RL2B_2 = 'P_RL_1RL2B_2'
     P_RL_2RL1_3a = 'P_RL_2RL1_3a'
     P_RL_2RL2B_3a = 'P_RL_2RL2B_3a'
+
+    # Reminder Questionnaires
+    P_QU_H1 = "P_QU_H1"
+    P_QU_H2 = "P_QU_H2"
+    P_QU_H4 = "P_QU_H4"
 
     # On request questionnaire fulfilments
     P_OR_H1 = 'P_OR_H1'
@@ -100,6 +109,7 @@ class PackCode(Enum):
 
 class Dataset(Enum):
     QM3_2 = 'QM3.2'
+    QM3_3 = 'QM3.3'
     QM3_4 = 'QM3.4'
     PPD1_1 = 'PPD1.1'
     PPD1_2 = 'PPD1.2'

--- a/app/constants.py
+++ b/app/constants.py
@@ -12,6 +12,15 @@ class ActionType(Enum):
     ICHHQW = 'ICHHQW'
     ICHHQN = 'ICHHQN'
 
+    # Reminder letters
+    P_RL_1RL1_1 = 'P_RL_1RL1_1'
+    P_RL_1RL2B_1 = 'P_RL_1RL2B_1'
+    P_RL_1RL4 = 'P_RL_1RL4'
+    P_RL_1RL1_2 = 'P_RL_1RL1_2'
+    P_RL_1RL2B_2 = 'P_RL_1RL2B_2'
+    P_RL_2RL1_3a = 'P_RL_2RL1_3a'
+    P_RL_2RL2B_3a = 'P_RL_2RL2B_3a'
+
     # On request questionnaire fulfilments
     P_OR_HX = 'P_OR_HX'
 
@@ -21,14 +30,6 @@ class ActionType(Enum):
     # Translation booklet fulfilments
     P_TB_TBX = 'P_TB_TBX'
 
-    # Reminder letters
-    P_RL_1RL1_1 = 'P_RL_1RL1_1'
-    P_RL_1RL2B_1 = 'P_RL_1RL2B_1'
-    P_RL_1RL4 = 'P_RL_1RL4'
-    P_RL_1RL1_2 = 'P_RL_1RL1_2'
-    P_RL_1RL2B_2 = 'P_RL_1RL2B_2'
-    P_RL_2RL1_3a = 'P_RL_2RL1_3a'
-    P_RL_2RL2B_3a = 'P_RL_2RL2B_3a'
 
 
 class PackCode(Enum):
@@ -42,6 +43,15 @@ class PackCode(Enum):
     P_IC_H2 = 'P_IC_H2'
     P_IC_H4 = 'P_IC_H4'
 
+    # Reminder letters
+    P_RL_1RL1_1 = 'P_RL_1RL1_1'
+    P_RL_1RL2B_1 = 'P_RL_1RL2B_1'
+    P_RL_1RL4 = 'P_RL_1RL4'
+    P_RL_1RL1_2 = 'P_RL_1RL1_2'
+    P_RL_1RL2B_2 = 'P_RL_1RL2B_2'
+    P_RL_2RL1_3a = 'P_RL_2RL1_3a'
+    P_RL_2RL2B_3a = 'P_RL_2RL2B_3a'
+
     # On request questionnaire fulfilments
     P_OR_H1 = 'P_OR_H1'
     P_OR_H2 = 'P_OR_H2'
@@ -53,15 +63,6 @@ class PackCode(Enum):
     P_OR_HC2 = 'P_OR_HC2'
     P_OR_HC2W = 'P_OR_HC2W'
     P_OR_HC4 = 'P_OR_HC4'
-
-    # Reminder letters
-    P_RL_1RL1_1 = 'P_RL_1RL1_1'
-    P_RL_1RL2B_1 = 'P_RL_1RL2B_1'
-    P_RL_1RL4 = 'P_RL_1RL4'
-    P_RL_1RL1_2 = 'P_RL_1RL1_2'
-    P_RL_1RL2B_2 = 'P_RL_1RL2B_2'
-    P_RL_2RL1_3a = 'P_RL_2RL1_3a'
-    P_RL_2RL2B_3a = 'P_RL_2RL2B_3a'
 
     # Large print fulfilments
     P_LP_HL1 = "P_LP_HL1"

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -52,7 +52,9 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_TB_TBURD1: 'Translation Booklet for England & Wales - Urdu',
     PackCode.P_TB_TBVIE1: 'Translation Booklet for England & Wales - Vietnamese',
     PackCode.P_TB_TBYSH1: 'Translation Booklet for England & Wales - Yiddish',
-
+    PackCode.P_QU_H1: '3rd Reminder, Questionnaire - for England addresses',
+    PackCode.P_QU_H2: '3rd Reminder, Questionnaire - for Wales addresses',
+    PackCode.P_QU_H4: '2nd Reminder, Questionnaire - for Ireland addresses',
 }
 
 PACK_CODE_TO_DATASET = {
@@ -105,10 +107,14 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_TB_TBULS4: Dataset.PPD1_3,
     PackCode.P_TB_TBVIE1: Dataset.PPD1_3,
     PackCode.P_TB_TBYSH1: Dataset.PPD1_3,
+    PackCode.P_QU_H1: Dataset.QM3_3,
+    PackCode.P_QU_H2: Dataset.QM3_3,
+    PackCode.P_QU_H4: Dataset.QM3_3,
 }
 
 DATASET_TO_SUPPLIER = {
     Dataset.QM3_2: Supplier.QM,
+    Dataset.QM3_3: Supplier.QM,
     Dataset.QM3_4: Supplier.QM,
     Dataset.PPD1_1: Supplier.PPO,
     Dataset.PPD1_2: Supplier.PPO,
@@ -141,7 +147,10 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.P_RL_1RL2B_2: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RL_2RL2B_3a: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_LP_HLX: PrintTemplate.PPO_LETTER_TEMPLATE,
-    ActionType.P_TB_TBX: PrintTemplate.PPO_LETTER_TEMPLATE
+    ActionType.P_TB_TBX: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_QU_H1: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
+    ActionType.P_QU_H2: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
+    ActionType.P_QU_H4: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
 
 }
 

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -15,7 +15,7 @@ from test.integration_tests.utilities import build_test_messages, send_action_me
 
 def test_ICL1E(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(print_questionnaire_message_template, 1, 'ICL1E', 'P_IC_ICL1')
+    icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'ICL1E', 'P_IC_ICL1')
     send_action_messages(icl1e_messages)
 
     # When

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -7,14 +7,15 @@ import paramiko
 import pgpy
 import pytest
 
+from app.constants import ActionType, PackCode
 from config import TestConfig
 from test.integration_tests.utilities import build_test_messages, send_action_messages, ICL_message_template, \
-    ICHHQ_message_template, P_OR_message_template, PPD1_3_message_template, reminder_message_template
+    print_questionnaire_message_template, P_OR_message_template, PPD1_3_message_template, reminder_message_template
 
 
 def test_ICL1E(sftp_client):
     # Given
-    icl1e_messages, _ = build_test_messages(ICHHQ_message_template, 1, 'ICL1E', 'P_IC_ICL1')
+    icl1e_messages, _ = build_test_messages(print_questionnaire_message_template, 1, 'ICL1E', 'P_IC_ICL1')
     send_action_messages(icl1e_messages)
 
     # When
@@ -92,7 +93,7 @@ def test_ICL4N(sftp_client):
 
 def test_ICHHQE(sftp_client):
     # Given
-    ichhqe_messages, _ = build_test_messages(ICHHQ_message_template, 3, 'ICHHQE', 'P_IC_H1')
+    ichhqe_messages, _ = build_test_messages(print_questionnaire_message_template, 3, 'ICHHQE', 'P_IC_H1')
     send_action_messages(ichhqe_messages)
 
     # When
@@ -124,7 +125,7 @@ def test_ICHHQE(sftp_client):
 
 def test_ICHHQW(sftp_client):
     # Given
-    ichhqw_messages, _ = build_test_messages(ICHHQ_message_template, 3, 'ICHHQW', 'P_IC_H2')
+    ichhqw_messages, _ = build_test_messages(print_questionnaire_message_template, 3, 'ICHHQW', 'P_IC_H2')
     send_action_messages(ichhqw_messages)
 
     # When
@@ -156,7 +157,7 @@ def test_ICHHQW(sftp_client):
 
 def test_ICHHQN(sftp_client):
     # Given
-    ichhqn_messages, _ = build_test_messages(ICHHQ_message_template, 3, 'ICHHQN', 'P_IC_H4')
+    ichhqn_messages, _ = build_test_messages(print_questionnaire_message_template, 3, 'ICHHQN', 'P_IC_H4')
     send_action_messages(ichhqn_messages)
 
     # When
@@ -496,6 +497,39 @@ def test_P_TB_TBPOL1(sftp_client):
         expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1\n')
 
 
+def test_P_QU_H2(sftp_client):
+    # Given
+    messages, _ = build_test_messages(print_questionnaire_message_template, 3, ActionType.P_QU_H2.value,
+                                      PackCode.P_QU_H2.value)
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_QM_DIRECTORY,
+                                                                                 'P_QU_H2')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': '3rd Reminder, Questionnaire - for Wales addresses',
+                                    'dataset': 'QM3.3'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_qm_supplier_private_key.asc'),
+        decryption_key_passphrase='supplier',
+        expected=(
+            '0|english_qid|1|welsh_qid|test_qm_coordinator_id|'
+            '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_QU_H2\n'
+            '2|english_qid|3|welsh_qid|test_qm_coordinator_id|'
+            '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_QU_H2\n'
+            '4|english_qid|5|welsh_qid|test_qm_coordinator_id|'
+            '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_QU_H2\n'))
+
+
 def test_our_decryption_key(sftp_client):
     # Given
     icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'ICL1E', 'P_IC_ICL1')
@@ -526,7 +560,7 @@ def get_print_and_manifest_filenames(sftp, remote_directory, pack_code, max_atte
             break
         sleep(1)
     else:
-        raise AssertionError('Reached max attempts before files were created')
+        pytest.fail('Reached max attempts before files were created')
     assert len(matched_manifest_files) == 1
     assert len(matched_print_files) == 1
     return matched_manifest_files[0], matched_print_files[0]

--- a/test/integration_tests/test_quarantine_files.py
+++ b/test/integration_tests/test_quarantine_files.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from time import sleep
 
+import pytest
+
 from test.integration_tests.utilities import build_test_messages, send_action_messages, ICL_message_template, \
-    ICHHQ_message_template
+    print_questionnaire_message_template
 
 QUARANTINED_FILES_DIRECTORY = Path(__file__).parents[2].joinpath('working_files',
                                                                  'quarantined_files')
@@ -28,7 +30,7 @@ def test_icl1e_with_duplicate_uacs_is_quarantined():
 
 def test_ichhqw_with_duplicate_uacs_is_quarantined():
     # Given
-    messages, batch_id = build_test_messages(ICHHQ_message_template, 3, 'ICHHQW', 'P_IC_H2')
+    messages, batch_id = build_test_messages(print_questionnaire_message_template, 3, 'ICHHQW', 'P_IC_H2')
     messages[0]['uac'] = 'test_duplicate'
     messages[2]['uacWales'] = 'test_duplicate'
     send_action_messages(messages)
@@ -53,4 +55,4 @@ def wait_for_quarantined_file(expected_quarantined_file, max_attempts=10):
             break
         sleep(1)
     else:
-        raise AssertionError('Reached max attempts before file was quarantined created')
+        pytest.fail('Reached max attempts before file was quarantined created')

--- a/test/integration_tests/utilities.py
+++ b/test/integration_tests/utilities.py
@@ -41,7 +41,7 @@ PPD1_3_message_template = {
     "packCode": None
 }
 
-ICHHQ_message_template = {
+print_questionnaire_message_template = {
     "actionType": None,
     "batchId": None,
     "batchQuantity": None,
@@ -57,6 +57,7 @@ ICHHQ_message_template = {
     "postcode": "NPXXXX",
     "packCode": None
 }
+
 P_OR_message_template = {
     "actionType": None,
     "batchId": None,


### PR DESCRIPTION
# Motivation and Context
We need to send scheduler reminder questionnaires.

# What has changed
* Add mappings and constants for questionnaire pack codes
* Add test for welsh reminder questionnaire print file

# How to test?
Build and test with the linked action scheduler and acceptance test branches

# Links
https://trello.com/c/4GUC0HS0/723-rmc-157-schedule-generate-and-distribute-reminder-pqs-5
https://github.com/ONSdigital/census-rm-action-scheduler/pull/32