### PR TITLE
added response driven reminders mappings and tests

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -38,6 +38,14 @@ class ActionType(Enum):
     P_QU_H2 = 'P_QU_H2'
     P_QU_H4 = 'P_QU_H4'
 
+    # Response driven reminders
+    P_RD_2RL1_1 = 'P_RD_2RL1_1'
+    P_RD_2RL2B_1 = 'P_RD_2RL2B_1'
+    P_RD_2RL1_2 = 'P_RD_2RL1_2'
+    P_RD_2RL2B_2 = 'P_RD_2RL2B_2'
+    P_RD_2RL1_3 = 'P_RD_2RL1_3'
+    P_RD_2RL2B_3 = 'P_RD_2RL2B_3'
+
 
 class PackCode(Enum):
     # Initial contact letters
@@ -114,6 +122,13 @@ class PackCode(Enum):
     P_TB_TBURD1 = "P_TB_TBURD1"
     P_TB_TBVIE1 = "P_TB_TBVIE1"
     P_TB_TBYSH1 = "P_TB_TBYSH1"
+
+    P_RD_2RL1_1 = 'P_RD_2RL1_1'
+    P_RD_2RL2B_1 = 'P_RD_2RL2B_1'
+    P_RD_2RL1_2 = 'P_RD_2RL1_2'
+    P_RD_2RL2B_2 = 'P_RD_2RL2B_2'
+    P_RD_2RL1_3 = 'P_RD_2RL1_3'
+    P_RD_2RL2B_3 = 'P_RD_2RL2B_3'
 
 
 class Dataset(Enum):

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -59,6 +59,12 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_QU_H1: '3rd Reminder, Questionnaire - for England addresses',
     PackCode.P_QU_H2: '3rd Reminder, Questionnaire - for Wales addresses',
     PackCode.P_QU_H4: '2nd Reminder, Questionnaire - for Ireland addresses',
+    PackCode.P_RD_2RL1_1: 'Response driven reminder group 1 English',
+    PackCode.P_RD_2RL2B_1: 'Response driven reminder group 1 Welsh',
+    PackCode.P_RD_2RL1_2: 'Response driven reminder group 2 English',
+    PackCode.P_RD_2RL2B_2: 'Response driven reminder group 2 Welsh',
+    PackCode.P_RD_2RL1_3: 'Response driven reminder group 3 English',
+    PackCode.P_RD_2RL2B_3: 'Response driven reminder group 3 Welsh'
 }
 
 PACK_CODE_TO_DATASET = {
@@ -118,6 +124,12 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_QU_H1: Dataset.QM3_3,
     PackCode.P_QU_H2: Dataset.QM3_3,
     PackCode.P_QU_H4: Dataset.QM3_3,
+    PackCode.P_RD_2RL1_1: Dataset.PPD1_2,
+    PackCode.P_RD_2RL2B_1: Dataset.PPD1_2,
+    PackCode.P_RD_2RL1_2: Dataset.PPD1_2,
+    PackCode.P_RD_2RL2B_2: Dataset.PPD1_2,
+    PackCode.P_RD_2RL1_3: Dataset.PPD1_2,
+    PackCode.P_RD_2RL2B_3: Dataset.PPD1_2
 }
 
 DATASET_TO_SUPPLIER = {
@@ -160,7 +172,12 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.P_QU_H1: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
     ActionType.P_QU_H2: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
     ActionType.P_QU_H4: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
-
+    ActionType.P_RD_2RL1_1: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_2RL2B_1: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_2RL1_2: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_2RL2B_2: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_2RL1_3: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_2RL2B_3: PrintTemplate.PPO_LETTER_TEMPLATE,
 }
 
 SUPPLIER_TO_PRINT_TEMPLATE = {

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -638,6 +638,162 @@ def test_P_QU_H2(sftp_client):
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_QU_H2\n'))
 
 
+def test_P_RD_2RL1_1(sftp_client):
+    # Given
+    messages, _ = build_test_messages(reminder_message_template, 1, 'P_RD_2RL1_1', 'P_RD_2RL1_1')
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_RD_2RL1_1')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 1 English',
+                                    'dataset': 'PPD1.2'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_1\n')
+
+
+def test_P_RD_2RL2B_1(sftp_client):
+    # Given
+    messages, _ = build_test_messages(reminder_message_template, 1, 'P_RD_2RL2B_1', 'P_RD_2RL2B_1')
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_RD_2RL2B_1')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 1 Welsh',
+                                    'dataset': 'PPD1.2'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_1\n')
+
+
+def test_P_RD_2RL1_2(sftp_client):
+    # Given
+    messages, _ = build_test_messages(reminder_message_template, 1, 'P_RD_2RL1_2', 'P_RD_2RL1_2')
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_RD_2RL1_2')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 2 English',
+                                    'dataset': 'PPD1.2'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_2\n')
+
+
+def test_P_RD_2RL2B_2(sftp_client):
+    # Given
+    messages, _ = build_test_messages(reminder_message_template, 1, 'P_RD_2RL2B_2', 'P_RD_2RL2B_2')
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_RD_2RL2B_2')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 2 Welsh',
+                                    'dataset': 'PPD1.2'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_2\n')
+
+
+def test_P_RD_2RL1_3(sftp_client):
+    # Given
+    messages, _ = build_test_messages(reminder_message_template, 1, 'P_RD_2RL1_3', 'P_RD_2RL1_3')
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_RD_2RL1_3')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 3 English',
+                                    'dataset': 'PPD1.2'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_3\n')
+
+
+def test_P_RD_2RL2B_3(sftp_client):
+    # Given
+    messages, _ = build_test_messages(reminder_message_template, 1, 'P_RD_2RL2B_3', 'P_RD_2RL2B_3')
+    send_action_messages(messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'P_RD_2RL2B_3')
+
+    # Then
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 3 Welsh',
+                                    'dataset': 'PPD1.2'})
+
+    get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_3\n')
+
+
 def test_our_decryption_key(sftp_client):
     # Given
     icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'ICL1E', 'P_IC_ICL1')


### PR DESCRIPTION
# Motivation and Context
add response driven by LSOA reminders

# What has changed
New mappings and related tests

# How to test?
With ATs and actionscheduler on same branch

# Links
https://trello.com/c/EIr1NVJi/1119-rmc-187b-processing-response-driven-interventions-5
