### PR TITLE
Tidy up files on sftp failure

### DIFF
--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -36,7 +36,7 @@ def process_complete_file(print_file: Path, pack_code: PackCode, batch_id, batch
         copy_files_to_sftp(file_paths, SUPPLIER_TO_SFTP_DIRECTORY[supplier])
 
     except Exception as ex:
-        context_logger.exception('Failed to send files to SFTP', file_paths=list(map(str, file_paths)))
+        context_logger.error('Failed to send files to SFTP', file_paths=list(map(str, file_paths)))
         context_logger.warn('Deleting failed encrypted and manifest print files', file_paths=list(map(str, file_paths)))
         delete_local_files(file_paths)
         raise ex

--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -18,24 +18,34 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def process_complete_file(print_file: Path, pack_code: PackCode):
+def process_complete_file(print_file: Path, pack_code: PackCode, batch_id, batch_quantity):
+    context_logger = logger.bind(pack_code=pack_code.value, batch_id=batch_id, batch_quantity=batch_quantity)
     supplier = DATASET_TO_SUPPLIER[PACK_CODE_TO_DATASET[pack_code]]
 
-    logger.info('Encrypting print_file', file_name=print_file.name)
+    context_logger.info('Encrypting print file')
     encrypted_print_file, filename = encrypt_print_file(print_file, pack_code, supplier)
 
     manifest_file = Config.ENCRYPTED_FILES_DIRECTORY.joinpath(f'{filename}.manifest')
-    logger.info('Creating manifest print_file', manifest_file=manifest_file.name)
+    context_logger.info('Creating manifest for print file', manifest_file=manifest_file.name)
     generate_manifest_file(manifest_file, encrypted_print_file, pack_code)
     file_paths = [encrypted_print_file, manifest_file]
 
-    logger.info('Sending files to SFTP', file_paths=list(map(str, file_paths)))
-    copy_files_to_sftp(file_paths, SUPPLIER_TO_SFTP_DIRECTORY[supplier])
+    context_logger.info('Sending files to SFTP', file_paths=list(map(str, file_paths)))
+
+    try:
+        copy_files_to_sftp(file_paths, SUPPLIER_TO_SFTP_DIRECTORY[supplier])
+
+    except Exception as ex:
+        context_logger.exception('Failed to send files to SFTP', file_paths=list(map(str, file_paths)))
+        context_logger.warn('Deleting failed encrypted and manifest print files', file_paths=list(map(str, file_paths)))
+        delete_local_files(file_paths)
+        raise ex
 
     # TODO upload encrypted print file and manifest to GCS
 
+    context_logger.info('Successfully sent print files to SFTP', file_paths=list(map(str, file_paths)))
     file_paths.append(print_file)
-    logger.info('Deleting local files', file_paths=list(map(str, file_paths)))
+    context_logger.info('Deleting local files', file_paths=list(map(str, file_paths)))
     delete_local_files(file_paths)
 
     # Wait for a second so there is no chance of reusing the same file name
@@ -71,7 +81,7 @@ def check_partial_files(partial_files_dir: Path):
                 logger.warn('Quarantining print file with duplicates', partial_file_name=print_file.name)
                 quarantine_partial_file(print_file)
                 return
-            process_complete_file(print_file, pack_code)
+            process_complete_file(print_file, pack_code, batch_id, batch_quantity)
 
 
 def get_metadata_from_partial_file_name(partial_file_name: str):

--- a/conftest.py
+++ b/conftest.py
@@ -1,20 +1,28 @@
+import os
 import shutil
-from pathlib import Path
+from collections import namedtuple
 
 import pytest
+
+# Set the ENVIRONMENT to TEST before the first time config is imported so the app uses TestConfig
+os.environ['ENVIRONMENT'] = 'TEST'
+from config import TestConfig  # noqa: E402, out of order by necessity
+
+TestDirectories = namedtuple('TestDirectories', ['test_files', 'partial_files', 'encrypted_files', 'quarantined_files'])
 
 
 @pytest.fixture
 def cleanup_test_files():
-    test_file_path = Path(__file__).parent.resolve().joinpath('tmp_test_files')
+    test_file_path = TestConfig.TMP_TEST_DIRECTORY
     if test_file_path.exists():
         shutil.rmtree(test_file_path)
     test_file_path.mkdir()
-    partial_files_directory = test_file_path.joinpath('partial_files/')
-    encrypted_files_directory = test_file_path.joinpath('encrypted_files/')
-    quarantined_file_directory = test_file_path.joinpath('quarantined_files/')
-    partial_files_directory.mkdir(exist_ok=True)
+    cleanup_test_files.partial_files = TestConfig.PARTIAL_FILES_DIRECTORY
+    encrypted_files_directory = TestConfig.ENCRYPTED_FILES_DIRECTORY
+    quarantined_file_directory = TestConfig.QUARANTINED_FILES_DIRECTORY
+    cleanup_test_files.partial_files.mkdir(exist_ok=True)
     encrypted_files_directory.mkdir(exist_ok=True)
     quarantined_file_directory.mkdir(exist_ok=True)
-    yield test_file_path, partial_files_directory, encrypted_files_directory, quarantined_file_directory
+    yield TestDirectories(test_file_path, cleanup_test_files.partial_files, encrypted_files_directory,
+                          quarantined_file_directory)
     shutil.rmtree(test_file_path)

--- a/test/unit_tests/app/__init__.py
+++ b/test/unit_tests/app/__init__.py
@@ -1,3 +1,0 @@
-import os
-
-os.environ['ENVIRONMENT'] = 'TEST'

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -11,7 +11,7 @@ import pytest
 
 from app.constants import PackCode
 from app.file_sender import copy_files_to_sftp, process_complete_file, \
-    check_partial_has_no_duplicates, quarantine_partial_file
+    check_partial_has_no_duplicates, quarantine_partial_file, check_partial_files
 from app.manifest_file_builder import generate_manifest_file
 from config import TestConfig
 
@@ -51,10 +51,10 @@ def test_processing_complete_file_uploads_correct_files(cleanup_test_files):
     iso_mocked = mock_time.strftime("%Y-%m-%dT%H-%M-%S")
 
     assert put_sftp_call_kwargs[0]['local_path'] == str(
-        cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mocked}.csv.gpg'))
+        cleanup_test_files.encrypted_files.joinpath(f'P_IC_ICL1_{iso_mocked}.csv.gpg'))
     assert put_sftp_call_kwargs[0]['filename'] == f'P_IC_ICL1_{iso_mocked}.csv.gpg'
     assert put_sftp_call_kwargs[1]['local_path'] == str(
-        cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mocked}.manifest'))
+        cleanup_test_files.encrypted_files.joinpath(f'P_IC_ICL1_{iso_mocked}.manifest'))
     assert put_sftp_call_kwargs[1]['filename'] == f'P_IC_ICL1_{iso_mocked}.manifest'
 
 
@@ -71,8 +71,7 @@ def test_local_files_are_deleted_after_upload(cleanup_test_files):
 
 
 def test_generating_manifest_file_ppd(cleanup_test_files):
-    encrypted_directory = cleanup_test_files[2]
-    manifest_file = encrypted_directory.joinpath('P_IC_ICL1_2019-07-05T08-15-41.manifest')
+    manifest_file = cleanup_test_files.encrypted_files.joinpath('P_IC_ICL1_2019-07-05T08-15-41.manifest')
     print_file = resource_file_path.joinpath('P_IC_ICL1_2019-07-05T08-15-41.csv.gpg')
     generate_manifest_file(manifest_file, print_file, PackCode.P_IC_ICL1)
 
@@ -85,8 +84,7 @@ def test_generating_manifest_file_ppd(cleanup_test_files):
 
 
 def test_generating_manifest_file_qm(cleanup_test_files):
-    encrypted_directory = cleanup_test_files[2]
-    manifest_file = encrypted_directory.joinpath('P_IC_H1_2019-07-08T11-57-11.manifest')
+    manifest_file = cleanup_test_files.encrypted_files.joinpath('P_IC_H1_2019-07-08T11-57-11.manifest')
     print_file = resource_file_path.joinpath('P_IC_H1_2019-07-08T11-57-11.csv.gpg')
     generate_manifest_file(manifest_file, print_file, PackCode.P_IC_H1)
 
@@ -145,27 +143,47 @@ def test_failed_encrypted_files_and_manifests_are_deleted(cleanup_test_files):
     complete_file_path = Path(shutil.copyfile(resource_file_path.joinpath('ICL1E.P_IC_ICL1.1.1'),
                                               TestConfig.PARTIAL_FILES_DIRECTORY.joinpath('ICL1E.P_IC_ICL1.1.1')))
 
-    failure_exception_message = 'Simulate SFTP transfer failure'
+    sftp_failure_exception_message = 'Simulate SFTP transfer failure'
 
     def simulate_sftp_failure(*_args, **_kwargs):
-        raise Exception(failure_exception_message)
+        raise Exception(sftp_failure_exception_message)
 
-    mock_time = datetime(2019, 1, 1, 7, 6, 5)
-    iso_mock_time = mock_time.strftime("%Y-%m-%dT%H-%M-%S")
-
-    with patch('app.file_sender.copy_files_to_sftp') as patch_copy_files_to_sftp, \
-            patch('app.file_sender.delete_local_files') as patch_delete_local_files, \
-            pytest.raises(Exception) as raised_exception, \
-            patch('app.file_sender.datetime') as patch_datetime:
-        patch_datetime.utcnow.return_value = mock_time
-        patch_copy_files_to_sftp.side_effect = simulate_sftp_failure
+    with patch('app.file_sender.sftp.paramiko.SSHClient') as client, \
+            pytest.raises(Exception) as raised_exception:
+        client.return_value.open_sftp.side_effect = simulate_sftp_failure
 
         # When
         process_complete_file(complete_file_path, PackCode.P_IC_ICL1, '1', '1')
 
     # Then
-    patch_delete_local_files.assert_has_calls(
-        [call([cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mock_time}.csv.gpg'),
-               cleanup_test_files[2].joinpath(f'P_IC_ICL1_{iso_mock_time}.manifest')])])
+    # Check encrypted_files_directory is empty
+    assert not any(cleanup_test_files.encrypted_files.iterdir())
 
-    assert str(raised_exception.value) == failure_exception_message
+    # Check complete partial file is still there
+    assert complete_file_path.exists()
+
+    # Check original exception is re-raised
+    assert str(raised_exception.value) == sftp_failure_exception_message
+
+
+def test_check_partial_files_processes_complete_file(cleanup_test_files):
+    # Given
+    partial_file_path = Path(cleanup_test_files.partial_files.joinpath('ICL1E.P_IC_ICL1.1.1'))
+    partial_file_path.touch()
+
+    mock_storage_client = Mock()
+
+    # When
+    with patch('app.file_sender.sftp.paramiko.SSHClient') as client:
+        client.return_value.open_sftp.return_value = mock_storage_client  # mock the sftp client connection
+        mock_storage_client.stat.return_value.st_mode = paramiko.sftp_client.stat.S_IFDIR  # mock directory exists
+
+        check_partial_files(cleanup_test_files.partial_files)
+        client.assert_not_called()
+
+        Path(shutil.copyfile(resource_file_path.joinpath('ICL1E.P_IC_ICL1.1.1'),
+                             cleanup_test_files.partial_files.joinpath('ICL1E.P_IC_ICL1.1.1')))
+        check_partial_files(cleanup_test_files.partial_files)
+
+    # Then
+    client.assert_called_once()

--- a/test/unit_tests/app/test_message_listener.py
+++ b/test/unit_tests/app/test_message_listener.py
@@ -12,7 +12,6 @@ from run import logger_initial_config
 
 def test_invalid_action_types_are_nacked(cleanup_test_files, init_logger, caplog):
     # Given
-    partial_files_directory = cleanup_test_files[1]
     json_body = json.dumps({
         "actionType": "NOT_A_VALID_ACTION_TYPE",
         "batchId": "1",
@@ -34,7 +33,7 @@ def test_invalid_action_types_are_nacked(cleanup_test_files, init_logger, caplog
     mock_properties.message_id = 'mock_message_id'
 
     # When
-    print_message_callback(mock_channel, mock_method, mock_properties, json_body, partial_files_directory)
+    print_message_callback(mock_channel, mock_method, mock_properties, json_body, cleanup_test_files.partial_files)
 
     # Then
     mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag)
@@ -47,7 +46,6 @@ def test_invalid_action_types_are_nacked(cleanup_test_files, init_logger, caplog
 
 def test_valid_action_type_is_acked(cleanup_test_files):
     # Given
-    partial_files_directory = cleanup_test_files[1]
     json_body = json.dumps({
         "actionType": "ICL1E",
         "batchId": "1",
@@ -67,7 +65,7 @@ def test_valid_action_type_is_acked(cleanup_test_files):
     # When
     mock_channel = Mock()
     mock_method = Mock()
-    print_message_callback(mock_channel, mock_method, Mock(), json_body, partial_files_directory)
+    print_message_callback(mock_channel, mock_method, Mock(), json_body, cleanup_test_files.partial_files)
 
     # Then
     mock_channel.basic_ack.assert_called_with(delivery_tag=mock_method.delivery_tag)
@@ -88,14 +86,14 @@ def test_start_message_listener_queues_ready(_patch_rabbit):
 def test_invalid_json_messages_are_nacked(cleanup_test_files, init_logger, caplog):
     # Given
     invalid_json_body = "not_valid_json"
-    partial_files_directory = cleanup_test_files[1]
     mock_channel = Mock()
     mock_method = Mock()
     mock_properties = Mock()
     mock_properties.message_id = 'mock_message_id'
 
     # When
-    print_message_callback(mock_channel, mock_method, mock_properties, invalid_json_body, partial_files_directory)
+    print_message_callback(mock_channel, mock_method, mock_properties, invalid_json_body,
+                           cleanup_test_files.partial_files)
 
     # Then
     mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag)
@@ -109,7 +107,7 @@ def test_template_not_found_messages_are_nacked(cleanup_test_files, init_logger,
     # Given
     class MockActionType(Enum):
         VALID_ACTION_TYPE_NO_TEMPLATE = 'VALID_ACTION_TYPE_NO_TEMPLATE'
-    partial_files_directory = cleanup_test_files[1]
+
     json_body = json.dumps({
         "actionType": MockActionType.VALID_ACTION_TYPE_NO_TEMPLATE.value,
         "batchId": "1",
@@ -132,7 +130,7 @@ def test_template_not_found_messages_are_nacked(cleanup_test_files, init_logger,
 
     # When
     with patch('app.print_file_builder.ActionType', new=MockActionType):
-        print_message_callback(mock_channel, mock_method, mock_properties, json_body, partial_files_directory)
+        print_message_callback(mock_channel, mock_method, mock_properties, json_body, cleanup_test_files.partial_files)
 
     # Then
     mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag)

--- a/test/unit_tests/app/test_print_file_builder.py
+++ b/test/unit_tests/app/test_print_file_builder.py
@@ -8,7 +8,6 @@ from app.print_file_builder import generate_print_row
 
 def test_generate_print_row_valid_ICL1E(cleanup_test_files):
     # Given
-    partial_files_directory = cleanup_test_files[1]
     json_body = json.dumps({
         "actionType": "ICL1E",
         "batchId": "1",
@@ -23,17 +22,16 @@ def test_generate_print_row_valid_ICL1E(cleanup_test_files):
     })
 
     # When
-    generate_print_row(json_body, partial_files_directory)
+    generate_print_row(json_body, cleanup_test_files.partial_files)
 
     # Then
-    generated_print_file = partial_files_directory.joinpath('ICL1E.P_IC_ICL1.1.3')
+    generated_print_file = cleanup_test_files.partial_files.joinpath('ICL1E.P_IC_ICL1.1.3')
     assert generated_print_file.read_text() == ('test_uac|test_caseref||||123 Fake Street'
                                                 '|Duffryn||Newport|NPXXXX|P_IC_ICL1\n')
 
 
 def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
     # Given
-    partial_files_directory = cleanup_test_files[1]
     json_body = json.dumps({
         "actionType": "ICHHQE",
         "batchId": "1",
@@ -52,10 +50,10 @@ def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
     })
 
     # When
-    generate_print_row(json_body, partial_files_directory)
+    generate_print_row(json_body, cleanup_test_files.partial_files)
 
     # Then
-    generated_print_file = partial_files_directory.joinpath('ICHHQE.P_IC_H1.1.3')
+    generated_print_file = cleanup_test_files.partial_files.joinpath('ICHHQE.P_IC_H1.1.3')
     assert generated_print_file.read_text() == (
         'test_uac|test_qid|test_wales_uac|test_wales_qid|test_qm_coordinator_id|'
         '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n')
@@ -63,7 +61,6 @@ def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
 
 def test_generate_print_row_invalid_action_type(cleanup_test_files):
     # Given
-    partial_files_directory = cleanup_test_files[1]
     json_body = json.dumps({
         "actionType": "NOT_A_VALID_ACTION_TYPE",
         "batchId": "1",
@@ -79,4 +76,4 @@ def test_generate_print_row_invalid_action_type(cleanup_test_files):
 
     # When/Then
     with pytest.raises(MalformedMessageError):
-        generate_print_row(json_body, partial_files_directory)
+        generate_print_row(json_body, cleanup_test_files.partial_files)


### PR DESCRIPTION
# Motivation and Context
If an SFTP transfer fails it currently leaves the two encrypted files orphaned requiring manual clean up. It can safely delete these files as it will keep retrying, triggered by the complete partial print file which stays where it is until after a successful upload. Also we found that following a batch through the logs is difficult because it was not logging a unique ID of the batch.

# What has changed
* Delete failed encrypted files on SFTP errors
* Improve logging of print file processing
* Add test for encrypted file cleanup on failure
* Add test for partial file checker, small test refactor

# How to test?
Build and run the image locally or in k8s. Take down the SFTP then trigger a printer action. You should see the print file service fail to send, but clean up the encrypted files and log that it is doing that. When you bring the SFTP back up it should successfully send the files.

# Links
https://trello.com/c/5OIVOYeb/1224-print-file-service-should-tidy-up-orphaned-files-if-the-sftp-transfer-fails