### PR TITLE
Force quarantine message delivery mode to persistent

### DIFF
--- a/app/message_error_handler.py
+++ b/app/message_error_handler.py
@@ -3,6 +3,7 @@ import hashlib
 import logging
 
 import requests
+from pika.spec import PERSISTENT_DELIVERY_MODE
 from structlog import wrap_logger
 
 from app.rabbit_context import RabbitContext
@@ -47,6 +48,7 @@ def _quarantine_message_in_exception_manager(body: bytes, message_hash, exceptio
 
 
 def _quarantine_message_in_rabbit(body: bytes, properties):
+    properties.delivery_mode = PERSISTENT_DELIVERY_MODE
     with RabbitContext(queue_name=Config.RABBIT_QUARANTINE_QUEUE) as rabbit:
         rabbit.channel.basic_publish(Config.RABBIT_QUARANTINE_EXCHANGE,
                                      rabbit.queue_name,


### PR DESCRIPTION
# Motivation and Context
Belt and braces approach to ensure quarantined messages have a persistent delivery mode to prevent data loss.

# What has changed
* Force quarantine message delivery mode to persistent
* Check delivery mode in unit test
* Tidy up use of mock properties in unit tests

# How to test?
Build and run, quarantine a bad message and check it is persistent delivery mode.

# Links
https://trello.com/c/Z4dHoUUf/1325-investigate-persistent-msgs-on-rabbitmq-redelivery-quarantine