### PR TITLE
Two typo changes for md5sum and time created

### DIFF
--- a/app/manifest_file_builder.py
+++ b/app/manifest_file_builder.py
@@ -18,14 +18,14 @@ def create_manifest(print_file_path: Path, pack_code: PackCode) -> dict:
         'description': PACK_CODE_TO_DESCRIPTION[pack_code],
         'dataset': PACK_CODE_TO_DATASET[pack_code].value,
         'version': '1',
-        'manifestCreated': datetime.utcnow().isoformat(),
+        'manifestCreated': datetime.utcnow().isoformat(timespec='milliseconds') + 'Z',
         'sourceName': 'ONS_RM',
         'files': [
             {
                 'name': print_file_path.name,
                 'relativePath': './',
                 'sizeBytes': str(print_file_path.stat().st_size),
-                'md5Sum': hashlib.md5(print_file_path.read_text().encode()).hexdigest()
+                'md5sum': hashlib.md5(print_file_path.read_text().encode()).hexdigest()
             }
         ]
     }


### PR DESCRIPTION
Uppercase S changed to lowercase for md5sum and time manifestCreated shortened to 3 digits for milliseconds and Z on end

# Motivation and Context
Aligns what we have with the manifest in the supplier files

# What has changed
Time manifestCreated reduced to 3 milliseconds rather than 6 and a Z added to the end to denote Zulu/UTC time

# How to test?
Check against next manifest. Have run acceptance tests which have passed after being changed to account for lowercase 's'

# Links
https://trello.com/c/BWR2j88I

