### PR TITLE
messages are rejected and put onto delayed/quarantine queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The service is configured with environment variables, see [config.py](config.py)
 
 Development defaults can be used by setting `ENVIRONMENT=DEV`.
 
+When running the application in your IDE, you may get a log warnings similar to:
+```commandline
+objc[5506]: +[NSValue initialize] may have been in progress in another thread when fork() was called.
+objc[5506]: +[NSValue initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
+``` 
+To remove the warnings, add `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` to your run configuration
 ### Logging config
 The general log level is set with `LOG_LEVEL`.
 There is a separate setting for pika (rabbit client library) and paramiko (sftp client library) logging, `LOG_LEVEL_PIKA` and `LOG_LEVEL_PARAMIKO` respectively which may be useful for diagnosing specific issues.

--- a/app/json_helper.py
+++ b/app/json_helper.py
@@ -1,0 +1,10 @@
+import datetime
+from json import JSONEncoder
+
+
+class CustomJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+            return f'{obj.isoformat()}Z'
+
+        return super(CustomJSONEncoder, self).default(obj)

--- a/test/unit_tests/app/test_json_helper.py
+++ b/test/unit_tests/app/test_json_helper.py
@@ -1,0 +1,11 @@
+import datetime
+import json
+
+from app.json_helper import CustomJSONEncoder
+
+
+def test_custom_json_encoder():
+    time = {'time': datetime.datetime(2019, 11, 18, 10, 59, 42)}
+    expected_time = '{"time": "2019-11-18T10:59:42Z"}'
+    encoded_time = json.dumps(time, cls=CustomJSONEncoder)
+    assert encoded_time == expected_time

--- a/test/unit_tests/app/test_message_error_handler.py
+++ b/test/unit_tests/app/test_message_error_handler.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import hashlib
 import json
 from unittest.mock import Mock, patch
@@ -106,7 +107,7 @@ def test_handle_error_quarantine_message(init_logger, caplog):
     processing_exception = Exception('An exception during message processing')
     mock_advice = {'skipIt': True}
 
-    expected_quarantine_message_dict = {
+    expected_quarantine_message = json.dumps({
         'messageHash': message_hash,
         'messagePayload': base64.b64encode(message).decode(),
         'service': TestConfig.NAME,
@@ -114,10 +115,10 @@ def test_handle_error_quarantine_message(init_logger, caplog):
         'exceptionClass': type(processing_exception).__name__,
         'routingKey': TestConfig.RABBIT_ROUTING_KEY,
         'contentType': 'application/json',
-        'headers': None,
-    }
-    expected_quarantine_message = json.dumps(expected_quarantine_message_dict)
-    properties = BasicProperties(content_type='application/json')
+        'headers': {"time": "2019-11-18T10:59:42Z"},
+    })
+    properties = BasicProperties(content_type='application/json',
+                                 headers={'time': datetime.datetime(2019, 11, 18, 10, 59, 42)})
     # When
     with patch('app.message_error_handler.requests.post') as patched_post, patch(
             'app.message_error_handler.RabbitContext') as patched_rabbit:

--- a/test/unit_tests/app/test_message_listener.py
+++ b/test/unit_tests/app/test_message_listener.py
@@ -35,7 +35,7 @@ def test_invalid_action_types_are_nacked(cleanup_test_files, init_logger, caplog
     print_message_callback(mock_channel, mock_method, mock_properties, json_body, cleanup_test_files.partial_files)
 
     # Then
-    mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag)
+    mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag, requeue=False)
     mock_channel.basic_ack.assert_not_called()
     assert "'NOT_A_VALID_ACTION_TYPE' is not a valid ActionType" in caplog.text
     assert 'Could not process message' in caplog.text
@@ -96,7 +96,7 @@ def test_invalid_json_messages_are_nacked(cleanup_test_files, init_logger, caplo
                            cleanup_test_files.partial_files)
 
     # Then
-    mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag)
+    mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag, requeue=False)
     mock_channel.basic_ack.assert_not_called()
     assert 'Could not process message' in caplog.text
     assert f'"message_hash": "{actual_hash}"' in caplog.text
@@ -134,7 +134,7 @@ def test_template_not_found_messages_are_nacked(cleanup_test_files, init_logger,
         print_message_callback(mock_channel, mock_method, mock_properties, json_body, cleanup_test_files.partial_files)
 
     # Then
-    mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag)
+    mock_channel.basic_nack.assert_called_with(delivery_tag=mock_method.delivery_tag, requeue=False)
     mock_channel.basic_ack.assert_not_called()
     assert 'Template not found for action type: \\"VALID_ACTION_TYPE_NO_TEMPLATE\\"' in caplog.text
     assert 'Could not process message' in caplog.text


### PR DESCRIPTION
# Motivation and Context
When messages are rejected they should be put onto the delayedRedeliveryQueue and quarantine queue. This changes makes it happen
# What has changed
- Messages rejected get put onto redelivered and quarantine queue
- Added custom json encoder class

# How to test?
- Run `make build_and_test` to test the service
- Run the acceptance tests with [PR](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/147)

# Links
[Trello](https://trello.com/c/ldIswXNl/)
