### PR TITLE
Fix default logger date format

### DIFF
--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ class Config:
 
     NAME = os.getenv('NAME', 'census-rm-print-file-service')
     LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
-    LOG_DATE_FORMAT = os.getenv('LOG_DATE_FORMAT', '%Y-%m-%dT%H:%M%s')
+    LOG_DATE_FORMAT = os.getenv('LOG_DATE_FORMAT', '%Y-%m-%dT%H:%M:%s')
     LOG_LEVEL_PIKA = os.getenv('LOG_LEVEL_PIKA', 'ERROR')
     LOG_LEVEL_PARAMIKO = os.getenv('LOG_LEVEL_PARAMIKO', 'ERROR')
 


### PR DESCRIPTION
# Motivation and Context
Default log date format is missing a colon separator

# What has changed
* Fix default logger date format

# How to test?
Check the logger date format

# Links
https://trello.com/c/GY5GWfIQ/447-fix-print-file-service-default-log-date-format