### PR TITLE
Split partial files before attempting encryption

### DIFF
--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -1,6 +1,5 @@
 import csv
 import logging
-import sys
 from datetime import datetime
 from pathlib import Path
 from time import sleep
@@ -19,8 +18,7 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def process_complete_file(complete_partial_file: Path, action_type: ActionType, pack_code: PackCode, batch_id,
-                          batch_quantity, context_logger):
+def process_complete_file(complete_partial_file: Path, pack_code: PackCode, context_logger):
     supplier = DATASET_TO_SUPPLIER[PACK_CODE_TO_DATASET[pack_code]]
 
     context_logger.info('Encrypting print file')
@@ -126,7 +124,7 @@ def check_partial_files(partial_files_dir: Path):
             if split_overs_sized_partial_file(partial_file, action_type, pack_code, batch_id, batch_quantity,
                                               context_logger):
                 return
-            process_complete_file(partial_file, action_type, pack_code, batch_id, batch_quantity, context_logger)
+            process_complete_file(partial_file, pack_code, context_logger)
 
 
 def split_overs_sized_partial_file(complete_partial_file, action_type, pack_code, batch_id, batch_quantity,
@@ -181,5 +179,5 @@ def check_partial_has_no_duplicates(partial_file_path: Path, pack_code: PackCode
                 return False
             for uac_column in uac_columns:
                 uacs.add(row[uac_column])
-    context_logger.info('Finished checking for duplicates', uac_set_memory=sys.getsizeof(uacs))
+    context_logger.info('Finished checking for duplicates')
     return True

--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import sys
 from datetime import datetime
 from pathlib import Path
 from time import sleep
@@ -24,14 +25,6 @@ def process_complete_file(complete_partial_file: Path, action_type: ActionType, 
 
     context_logger.info('Encrypting print file')
     encrypted_print_file, filename = encrypt_print_file(complete_partial_file, pack_code, supplier)
-
-    if is_file_over_size(encrypted_print_file):
-        context_logger.info('Encrypted file too large, splitting partial file',
-                            file_size_bytes=encrypted_print_file.stat().st_size)
-        split_partial_file(complete_partial_file, action_type, pack_code, batch_id, int(batch_quantity))
-        context_logger.info('File successfully split, removing encrypted file')
-        encrypted_print_file.unlink()
-        return
 
     manifest_file = Config.ENCRYPTED_FILES_DIRECTORY.joinpath(f'{filename}.manifest')
     context_logger.info('Creating manifest for print file', manifest_file=manifest_file.name)
@@ -75,17 +68,15 @@ def split_partial_file(partial_file: Path, action_type: ActionType, pack_code: P
     first_chunk_name = f'{action_type.value}.{pack_code.value}.{batch_id}_1.{first_chunk_quantity}'
     second_chunk_name = f'{action_type.value}.{pack_code.value}.{batch_id}_2.{batch_quantity - first_chunk_quantity}'
 
-    # TODO use more memory efficient method to read/write partial file
     with open(partial_file) as open_partial_file:
-        partial_file_lines = open_partial_file.readlines()
-    first_chunk_path = Config.PARTIAL_FILES_DIRECTORY.joinpath(first_chunk_name)
-    with open(first_chunk_path, 'w') as first_chunk_write:
-        first_chunk_write.write(''.join(partial_file_lines[:first_chunk_quantity]))
-
-    second_chunk_path = Config.PARTIAL_FILES_DIRECTORY.joinpath(second_chunk_name)
-    with open(second_chunk_path, 'w') as second_chunk_write:
-        second_chunk_write.write(''.join(partial_file_lines[first_chunk_quantity:]))
-    del partial_file_lines
+        first_chunk_path = Config.PARTIAL_FILES_DIRECTORY.joinpath(first_chunk_name)
+        second_chunk_path = Config.PARTIAL_FILES_DIRECTORY.joinpath(second_chunk_name)
+        with open(first_chunk_path, 'w') as first_chunk_write, open(second_chunk_path, 'w') as second_chunk_write:
+            for idx, line in enumerate(open_partial_file, 1):
+                if idx <= first_chunk_quantity:
+                    first_chunk_write.write(line)
+                else:
+                    second_chunk_write.write(line)
 
     partial_file.unlink()
 
@@ -110,23 +101,43 @@ def quarantine_partial_file(partial_file_path: Path):
     logger.warn('Quarantined partial print file', quarantined_file_path=str(quarantine_destination))
 
 
+def is_split_file_batch_id(batch_id):
+    return batch_id.endswith('_1') or batch_id.endswith('_2')
+
+
 def check_partial_files(partial_files_dir: Path):
-    for print_file in partial_files_dir.rglob('*'):
-        action_type, pack_code, batch_id, batch_quantity = get_metadata_from_partial_file_name(print_file.name)
-        actual_number_of_lines = sum(1 for _ in print_file.open())
+    for partial_file in partial_files_dir.iterdir():
+        action_type, pack_code, batch_id, batch_quantity = get_metadata_from_partial_file_name(partial_file.name)
+        actual_number_of_lines = sum(1 for _ in partial_file.open())
         if int(batch_quantity) == actual_number_of_lines:
             context_logger = logger.bind(action_type=action_type.value,
                                          pack_code=pack_code.value,
                                          batch_id=batch_id,
                                          batch_quantity=batch_quantity)
 
-            context_logger.info('Checking complete file for duplicates')
-            if not check_partial_has_no_duplicates(print_file, pack_code):
+            if is_split_file_batch_id(batch_id):
+                context_logger.info('Partial file has already been checked and split, skipping duplicate check')
+            elif not check_partial_has_no_duplicates(partial_file, pack_code, context_logger):
                 context_logger.warn('Quarantining print file with duplicates')
-                quarantine_partial_file(print_file)
+                quarantine_partial_file(partial_file)
                 return
-            context_logger.info('File has no duplicates, beginning processing')
-            process_complete_file(print_file, action_type, pack_code, batch_id, batch_quantity, context_logger)
+            else:
+                context_logger.info('File has no duplicates, beginning processing')
+            if split_overs_sized_partial_file(partial_file, action_type, pack_code, batch_id, batch_quantity,
+                                              context_logger):
+                return
+            process_complete_file(partial_file, action_type, pack_code, batch_id, batch_quantity, context_logger)
+
+
+def split_overs_sized_partial_file(complete_partial_file, action_type, pack_code, batch_id, batch_quantity,
+                                   context_logger):
+    if is_file_over_size(complete_partial_file):
+        context_logger.info('Partial is file too large, splitting into two',
+                            file_size_bytes=complete_partial_file.stat().st_size)
+        split_partial_file(complete_partial_file, action_type, pack_code, batch_id, int(batch_quantity))
+        context_logger.info('File successfully split')
+        return True
+    return False
 
 
 def get_metadata_from_partial_file_name(partial_file_name: str):
@@ -156,7 +167,8 @@ def copy_files_to_sftp(file_paths: Collection[Path], remote_directory):
                     sftp_directory=sftp_client.sftp_directory)
 
 
-def check_partial_has_no_duplicates(partial_file_path: Path, pack_code: PackCode):
+def check_partial_has_no_duplicates(partial_file_path: Path, pack_code: PackCode, context_logger):
+    context_logger.info('Checking complete file for duplicates')
     uacs = set()
     fieldnames = SUPPLIER_TO_PRINT_TEMPLATE[DATASET_TO_SUPPLIER[PACK_CODE_TO_DATASET[pack_code]]]
     with open(partial_file_path) as partial_file:
@@ -164,10 +176,10 @@ def check_partial_has_no_duplicates(partial_file_path: Path, pack_code: PackCode
         uac_columns = {fieldname for fieldname in fieldnames if 'uac' in fieldname}
         for line_number, row in enumerate(reader, 1):
             if any((row.get(uac_column) and row.get(uac_column) in uacs) for uac_column in uac_columns):
-                logger.error('Duplicate uac found in print file',
-                             partial_file_name=partial_file_path.name,
-                             line_number=line_number)
+                context_logger.error('Duplicate uac found in print file',
+                                     line_number=line_number)
                 return False
             for uac_column in uac_columns:
                 uacs.add(row[uac_column])
+    context_logger.info('Finished checking for duplicates', uac_set_memory=sys.getsizeof(uacs))
     return True

--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ class Config:
 
     NAME = os.getenv('NAME', 'census-rm-print-file-service')
     LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
-    LOG_DATE_FORMAT = os.getenv('LOG_DATE_FORMAT', '%Y-%m-%dT%H:%M%s')
+    LOG_DATE_FORMAT = os.getenv('LOG_DATE_FORMAT', '%Y-%m-%dT%H:%M:%s')
     LOG_LEVEL_PIKA = os.getenv('LOG_LEVEL_PIKA', 'ERROR')
     LOG_LEVEL_PARAMIKO = os.getenv('LOG_LEVEL_PARAMIKO', 'ERROR')
 

--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ class Config:
     SFTP_PPO_DIRECTORY = os.getenv('SFTP_PPO_DIRECTORY')
     SFTP_QM_DIRECTORY = os.getenv('SFTP_QM_DIRECTORY')
 
-    MAX_FILE_SIZE_BYTES = int(os.getenv('MAX_FILE_SIZE_BYTES', 10 ** 9))
+    MAX_FILE_SIZE_BYTES = int(os.getenv('MAX_FILE_SIZE_BYTES', 9 * 10 ** 8))
 
     OUR_PUBLIC_KEY_PATH = Path(os.getenv('OUR_PUBLIC_KEY_PATH')) if os.getenv('OUR_PUBLIC_KEY_PATH') else None
     QM_SUPPLIER_PUBLIC_KEY_PATH = Path(os.getenv('QM_SUPPLIER_PUBLIC_KEY_PATH')) if os.getenv(

--- a/conftest.py
+++ b/conftest.py
@@ -31,8 +31,8 @@ def cleanup_test_files():
 
 
 @pytest.fixture
-def set_max_bytes():
-    TestConfig.MAX_FILE_SIZE_BYTES = int(10 ** 3)
+def reduce_max_partial_file_size():
+    TestConfig.MAX_FILE_SIZE_BYTES = int(5 * 10 ** 2)
     yield
     TestConfig.MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_BYTES_PRESET
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - QUARANTINED_FILES_DIRECTORY=/home/printfile/working_files/quarantined_files
       - PARTIAL_FILES_DIRECTORY=/home/printfile/working_files/partial_files
       - ENCRYPTED_FILES_DIRECTORY=/home/printfile/working_files/encrypted_files
-      - MAX_FILE_SIZE_BYTES=1740
+      - MAX_FILE_SIZE_BYTES=1024
     volumes:
       - ./working_files:/home/printfile/working_files
     restart: always

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import shutil
 from datetime import datetime


### PR DESCRIPTION
# Motivation and Context
We're still encrypting the whole partial file in memory, so we need to limit the size we attempt encryption at to what we can allocate in a single k8s pod. This PR moves the check and splitting to be done before the service tries to encrypt the file, ensuring it does not try to encrypt a file too large to fit in memory.

# What has changed
* Check partial file size before encryption
* Improve speed and memory use of splitting function
* Don't repeat duplicate UAC checks on already split files

# How to test?
Run the acceptance tests. 
Try feeding in a large (>900MB) partial file.

# Links
https://trello.com/c/HOjzdHs1/443-productionize-splitting-print-files-pre-encryption-8