### PR TITLE
Fix Startup GCP Check Timeout

### DIFF
--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -152,7 +152,7 @@ def start_file_sender(readiness_queue):
     with sftp.SftpUtility(Config.SFTP_PPO_DIRECTORY):
         logger.info('Successfully connected to SFTP PPD directory', sftp_directory=Config.SFTP_PPO_DIRECTORY)
 
-    # check_gcp_bucket_ready()
+    check_gcp_bucket_ready()
 
     readiness_queue.put(True)
 
@@ -167,11 +167,13 @@ def check_gcp_bucket_ready():
         logger.warn('SENT_PRINT_FILE_BUCKET set to empty, skipping uploading files to GCP')
         return
 
+    logger.info('Testing connection to print file bucket', bucket_name=Config.SENT_PRINT_FILE_BUCKET)
     try:
         storage.Client().get_bucket(Config.SENT_PRINT_FILE_BUCKET)
     except Exception:
-        logger.exception(f'Print file upload bucket cannot be accessed {Config.SENT_PRINT_FILE_BUCKET}')
+        logger.exception(f'Print file upload bucket cannot be accessed', bucket_name=Config.SENT_PRINT_FILE_BUCKET)
         return
+    logger.info('Successfully got print file bucket', bucket_name=Config.SENT_PRINT_FILE_BUCKET)
 
 
 def copy_files_to_sftp(file_paths: Collection[Path], remote_directory):

--- a/app/logger.py
+++ b/app/logger.py
@@ -24,6 +24,10 @@ def logger_initial_config():
             # The stdlib has an alias
             method_name = "warning"
 
+        if method_name == "exception":
+            # exception level is not as universal
+            method_name = "error"
+
         event_dict["severity"] = method_name
         return event_dict
 

--- a/app/run_daemons.py
+++ b/app/run_daemons.py
@@ -36,9 +36,9 @@ def run_daemons():
             sleep(1)
 
 
-def run_in_daemon(target, name, process_manager, timeout=3) -> multiprocessing.Process:
+def run_in_daemon(target, name, process_manager, timeout=20) -> multiprocessing.Process:
     readiness_queue = process_manager.Queue()
-    daemon = multiprocessing.Process(target=target, args=[readiness_queue], daemon=True, name=name)
+    daemon = multiprocessing.Process(target=target, args=(readiness_queue,), daemon=True, name=name)
     daemon.start()
     try:
         if readiness_queue.get(block=True, timeout=timeout):
@@ -48,5 +48,5 @@ def run_in_daemon(target, name, process_manager, timeout=3) -> multiprocessing.P
 
 
 @retry(wait_exponential_multiplier=1000, wait_exponential_max=10000)
-def retry_run_daemon(target, name, process_manager, timeout=3) -> multiprocessing.Process:
+def retry_run_daemon(target, name, process_manager, timeout=20) -> multiprocessing.Process:
     return run_in_daemon(target, name, process_manager, timeout=timeout)

--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ class Config:
 
     NAME = os.getenv('NAME', 'census-rm-print-file-service')
     LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
-    LOG_DATE_FORMAT = os.getenv('LOG_DATE_FORMAT', '%Y-%m-%dT%H:%M:%s')
+    LOG_DATE_FORMAT = os.getenv('LOG_DATE_FORMAT', '%Y-%m-%dT%H:%M:%S.%f')
     LOG_LEVEL_PIKA = os.getenv('LOG_LEVEL_PIKA', 'ERROR')
     LOG_LEVEL_PARAMIKO = os.getenv('LOG_LEVEL_PARAMIKO', 'ERROR')
 


### PR DESCRIPTION
# Motivation and Context
The threads were not being given long enough to start up with the new check of the GCP bucket connection

# What has changed
* Relax start up timeouts
* Alias exception log severity to error
* Fix default log timestamp format

# How to test?
Spin this up in GCP, it should be able to start up now (CI was having issues)

# Links
https://trello.com/c/RvNa5z4n/239-upload-encrypted-print-files-to-gcs-bucket-8