### PR TITLE
Add rows count attribute to manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ install:
 	pipenv install --dev
 
 check:
-	pipenv check
+	# TODO reinstate this once https://github.com/pypa/pipenv/issues/4188 is resolved
+	#pipenv check
 
 lint:
 	pipenv run flake8

--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -19,7 +19,7 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def process_complete_file(complete_partial_file: Path, pack_code: PackCode, context_logger):
+def process_complete_file(complete_partial_file: Path, pack_code: PackCode, context_logger, row_count):
     supplier = DATASET_TO_SUPPLIER[PACK_CODE_TO_DATASET[pack_code]]
 
     context_logger.info('Encrypting print file')
@@ -27,7 +27,7 @@ def process_complete_file(complete_partial_file: Path, pack_code: PackCode, cont
 
     manifest_file = Config.ENCRYPTED_FILES_DIRECTORY.joinpath(f'{filename}.manifest')
     context_logger.info('Creating manifest for print file', manifest_file=manifest_file.name)
-    generate_manifest_file(manifest_file, encrypted_print_file, pack_code)
+    generate_manifest_file(manifest_file, encrypted_print_file, pack_code, row_count)
     temporary_files_paths = [encrypted_print_file, manifest_file]
 
     context_logger.info('Sending files to SFTP', file_paths=list(map(str, temporary_files_paths)))
@@ -105,7 +105,7 @@ def is_split_file_batch_id(batch_id):
     return batch_id.endswith('_1') or batch_id.endswith('_2')
 
 
-def check_partial_files(partial_files_dir: Path):
+def check_partial_files(partial_files_dir: Path, row_count):
     for partial_file in partial_files_dir.iterdir():
         action_type, pack_code, batch_id, batch_quantity = get_metadata_from_partial_file_name(partial_file.name)
         actual_number_of_lines = sum(1 for _ in partial_file.open())
@@ -126,7 +126,7 @@ def check_partial_files(partial_files_dir: Path):
             if split_overs_sized_partial_file(partial_file, action_type, pack_code, batch_id, batch_quantity,
                                               context_logger):
                 return
-            process_complete_file(partial_file, pack_code, context_logger)
+            process_complete_file(partial_file, pack_code, context_logger, row_count)
 
 
 def split_overs_sized_partial_file(complete_partial_file, action_type, pack_code, batch_id, batch_quantity,

--- a/app/manifest_file_builder.py
+++ b/app/manifest_file_builder.py
@@ -7,12 +7,12 @@ from app.constants import PackCode
 from app.mappings import PACK_CODE_TO_DESCRIPTION, PACK_CODE_TO_DATASET
 
 
-def generate_manifest_file(manifest_file_path: Path, print_file_path: Path, pack_code: PackCode):
-    manifest = create_manifest(print_file_path, pack_code)
+def generate_manifest_file(manifest_file_path: Path, print_file_path: Path, pack_code: PackCode, row_count):
+    manifest = create_manifest(print_file_path, pack_code, row_count)
     manifest_file_path.write_text(json.dumps(manifest))
 
 
-def create_manifest(print_file_path: Path, pack_code: PackCode) -> dict:
+def create_manifest(print_file_path: Path, pack_code: PackCode, row_count) -> dict:
     return {
         'schemaVersion': '1',
         'description': PACK_CODE_TO_DESCRIPTION[pack_code],
@@ -25,7 +25,8 @@ def create_manifest(print_file_path: Path, pack_code: PackCode) -> dict:
                 'name': print_file_path.name,
                 'relativePath': './',
                 'sizeBytes': str(print_file_path.stat().st_size),
-                'md5sum': hashlib.md5(print_file_path.read_text().encode()).hexdigest()
+                'md5sum': hashlib.md5(print_file_path.read_text().encode()).hexdigest(),
+                'rows': row_count
             }
         ]
     }

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -898,7 +898,7 @@ def get_and_check_manifest_file(sftp, remote_manifest_path, expected_values, dec
         assert manifest_json[key] == value
     actual_row_count = len(decrypted_print_file.splitlines())
 
-    assert actual_row_count == manifest_json['files'][0]['row_count']
+    assert actual_row_count == manifest_json['files'][0]['rows']
     assert manifest_json['files'][0]['relativePath'] == './'
     assert manifest_json['sourceName'] == 'ONS_RM'
     assert manifest_json['schemaVersion'] == '1'

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -24,19 +24,19 @@ def test_ICL1E(sftp_client):
                                                                                  'P_IC_ICL1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Initial contact letter households - England',
-                                    'dataset': 'PPD1.1'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Initial contact letter households - England',
+                                    'dataset': 'PPD1.1'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_ICL1E_split_files(sftp_client):
@@ -95,19 +95,19 @@ def test_ICL2W(sftp_client):
                                                                                  'P_IC_ICL2B')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Initial contact letter households - Wales',
-                                    'dataset': 'PPD1.1'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL2B\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Initial contact letter households - Wales',
+                                    'dataset': 'PPD1.1'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_ICL4N(sftp_client):
@@ -121,19 +121,19 @@ def test_ICL4N(sftp_client):
                                                                                  'P_IC_ICL4')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Initial contact letter households - Northern Ireland',
-                                    'dataset': 'PPD1.1'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL4\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Initial contact letter households - Northern Ireland',
+                                    'dataset': 'PPD1.1'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_ICHHQE(sftp_client):
@@ -147,13 +147,7 @@ def test_ICHHQE(sftp_client):
                                                                                  'P_IC_H1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Initial contact questionnaire households - England',
-                                    'dataset': 'QM3.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -167,6 +161,12 @@ def test_ICHHQE(sftp_client):
             '4|english_qid|5|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n'))
 
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Initial contact questionnaire households - England',
+                                    'dataset': 'QM3.2'}, decrypted_print_file=decrypted_print_file)
+
 
 def test_ICHHQW(sftp_client):
     # Given
@@ -179,13 +179,7 @@ def test_ICHHQW(sftp_client):
                                                                                  'P_IC_H2')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Initial contact questionnaire households - Wales',
-                                    'dataset': 'QM3.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -199,6 +193,12 @@ def test_ICHHQW(sftp_client):
             '4|english_qid|5|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H2\n'))
 
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Initial contact questionnaire households - Wales',
+                                    'dataset': 'QM3.2'}, decrypted_print_file=decrypted_print_file)
+
 
 def test_ICHHQN(sftp_client):
     # Given
@@ -211,13 +211,7 @@ def test_ICHHQN(sftp_client):
                                                                                  'P_IC_H4')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Initial contact questionnaire households - Northern Ireland',
-                                    'dataset': 'QM3.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -231,6 +225,12 @@ def test_ICHHQN(sftp_client):
             '4|english_qid|5|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H4\n'))
 
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Initial contact questionnaire households - Northern Ireland',
+                                    'dataset': 'QM3.2'}, decrypted_print_file=decrypted_print_file)
+
 
 def test_P_OR_H1(sftp_client):
     # Given
@@ -243,13 +243,7 @@ def test_P_OR_H1(sftp_client):
                                                                                  'P_OR_H1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Household Questionnaire for England',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -259,6 +253,12 @@ def test_P_OR_H1(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H1\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H1\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H1\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Household Questionnaire for England',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_H2(sftp_client):
@@ -272,13 +272,7 @@ def test_P_OR_H2(sftp_client):
                                                                                  'P_OR_H2')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Household Questionnaire for Wales (English)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -288,6 +282,12 @@ def test_P_OR_H2(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H2\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H2\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H2\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Household Questionnaire for Wales (English)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_H2W(sftp_client):
@@ -301,13 +301,7 @@ def test_P_OR_H2W(sftp_client):
                                                                                  'P_OR_H2W')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Household Questionnaire for Wales (Welsh)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -317,6 +311,12 @@ def test_P_OR_H2W(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H2W\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H2W\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H2W\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Household Questionnaire for Wales (Welsh)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_H4(sftp_client):
@@ -330,13 +330,7 @@ def test_P_OR_H4(sftp_client):
                                                                                  'P_OR_H4')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Household Questionnaire for Northern Ireland (English)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -346,6 +340,12 @@ def test_P_OR_H4(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H4\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H4\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_H4\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Household Questionnaire for Northern Ireland (English)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_HC1(sftp_client):
@@ -359,13 +359,7 @@ def test_P_OR_HC1(sftp_client):
                                                                                  'P_OR_HC1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Continuation Questionnaire for England',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -375,6 +369,12 @@ def test_P_OR_HC1(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC1\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC1\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC1\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Continuation Questionnaire for England',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_HC2(sftp_client):
@@ -388,13 +388,7 @@ def test_P_OR_HC2(sftp_client):
                                                                                  'P_OR_HC2')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Continuation Questionnaire for Wales (English)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -404,6 +398,12 @@ def test_P_OR_HC2(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC2\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC2\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC2\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Continuation Questionnaire for Wales (English)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_HC2W(sftp_client):
@@ -417,13 +417,7 @@ def test_P_OR_HC2W(sftp_client):
                                                                                  'P_OR_HC2W')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Continuation Questionnaire for Wales (Welsh)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -433,6 +427,12 @@ def test_P_OR_HC2W(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC2W\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC2W\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC2W\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Continuation Questionnaire for Wales (Welsh)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_HC4(sftp_client):
@@ -446,13 +446,7 @@ def test_P_OR_HC4(sftp_client):
                                                                                  'P_OR_HC4')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Continuation Questionnaire for Northern Ireland (English)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -462,6 +456,12 @@ def test_P_OR_HC4(sftp_client):
             '0|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC4\n'
             '1|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC4\n'
             '2|english_qid||||Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_HC4\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Continuation Questionnaire for Northern Ireland (English)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_RL_1RL1_1(sftp_client):
@@ -475,19 +475,19 @@ def test_P_RL_1RL1_1(sftp_client):
                                                                                  'P_RL_1RL1_1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': '1st Reminder, Letter - for England addresses',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RL_1RL1_1\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': '1st Reminder, Letter - for England addresses',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_LP_HL1(sftp_client):
@@ -501,19 +501,19 @@ def test_P_LP_HL1(sftp_client):
                                                                                  'P_LP_HL1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Household Questionnaire Large Print pack for England',
-                                    'dataset': 'PPD1.3'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_LP_HL1\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Household Questionnaire Large Print pack for England',
+                                    'dataset': 'PPD1.3'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_TB_TBPOL1(sftp_client):
@@ -527,19 +527,19 @@ def test_P_TB_TBPOL1(sftp_client):
                                                                                  'P_TB_TBPOL1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Translation Booklet for England & Wales - Polish',
-                                    'dataset': 'PPD1.3'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Translation Booklet for England & Wales - Polish',
+                                    'dataset': 'PPD1.3'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_I1(sftp_client):
@@ -552,13 +552,7 @@ def test_P_OR_I1(sftp_client):
                                                                                  TestConfig.SFTP_QM_DIRECTORY,
                                                                                  'P_OR_I1')
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Individual Questionnaire for England',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -567,6 +561,12 @@ def test_P_OR_I1(sftp_client):
         expected=(
             '0|english_qid|1|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_I1\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Individual Questionnaire for England',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_I2(sftp_client):
@@ -579,13 +579,7 @@ def test_P_OR_I2(sftp_client):
                                                                                  TestConfig.SFTP_QM_DIRECTORY,
                                                                                  'P_OR_I2')
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Individual Questionnaire for Wales (English)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -594,6 +588,12 @@ def test_P_OR_I2(sftp_client):
         expected=(
             '0|english_qid|1|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_I2\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Individual Questionnaire for Wales (English)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_I2W(sftp_client):
@@ -606,13 +606,7 @@ def test_P_OR_I2W(sftp_client):
                                                                                  TestConfig.SFTP_QM_DIRECTORY,
                                                                                  'P_OR_I2W')
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Individual Questionnaire for Wales (Welsh)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -621,6 +615,12 @@ def test_P_OR_I2W(sftp_client):
         expected=(
             '0|english_qid|1|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_I2W\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Individual Questionnaire for Wales (Welsh)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_OR_I4(sftp_client):
@@ -633,13 +633,7 @@ def test_P_OR_I4(sftp_client):
                                                                                  TestConfig.SFTP_QM_DIRECTORY,
                                                                                  'P_OR_I4')
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Individual Questionnaire for Northern Ireland (English)',
-                                    'dataset': 'QM3.4'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -648,6 +642,12 @@ def test_P_OR_I4(sftp_client):
         expected=(
             '0|english_qid|1|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_OR_I4\n'))
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Individual Questionnaire for Northern Ireland (English)',
+                                    'dataset': 'QM3.4'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_QU_H2(sftp_client):
@@ -662,13 +662,7 @@ def test_P_QU_H2(sftp_client):
                                                                                  'P_QU_H2')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': '3rd Reminder, Questionnaire - for Wales addresses',
-                                    'dataset': 'QM3.3'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_QM_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
@@ -682,6 +676,12 @@ def test_P_QU_H2(sftp_client):
             '4|english_qid|5|welsh_qid|test_qm_coordinator_id|'
             '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_QU_H2\n'))
 
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_QM_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': '3rd Reminder, Questionnaire - for Wales addresses',
+                                    'dataset': 'QM3.3'}, decrypted_print_file=decrypted_print_file)
+
 
 def test_P_RD_2RL1_1(sftp_client):
     # Given
@@ -694,19 +694,19 @@ def test_P_RD_2RL1_1(sftp_client):
                                                                                  'P_RD_2RL1_1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Response driven reminder group 1 English',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_1\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 1 English',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_RD_2RL2B_1(sftp_client):
@@ -720,19 +720,19 @@ def test_P_RD_2RL2B_1(sftp_client):
                                                                                  'P_RD_2RL2B_1')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Response driven reminder group 1 Welsh',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_1\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 1 Welsh',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_RD_2RL1_2(sftp_client):
@@ -746,19 +746,19 @@ def test_P_RD_2RL1_2(sftp_client):
                                                                                  'P_RD_2RL1_2')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Response driven reminder group 2 English',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_2\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 2 English',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_RD_2RL2B_2(sftp_client):
@@ -772,19 +772,19 @@ def test_P_RD_2RL2B_2(sftp_client):
                                                                                  'P_RD_2RL2B_2')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Response driven reminder group 2 Welsh',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_2\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 2 Welsh',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_RD_2RL1_3(sftp_client):
@@ -798,19 +798,19 @@ def test_P_RD_2RL1_3(sftp_client):
                                                                                  'P_RD_2RL1_3')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Response driven reminder group 3 English',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_3\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 3 English',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_P_RD_2RL2B_3(sftp_client):
@@ -824,19 +824,19 @@ def test_P_RD_2RL2B_3(sftp_client):
                                                                                  'P_RD_2RL2B_3')
 
     # Then
-    get_and_check_manifest_file(sftp=sftp_client,
-                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
-                                expected_values={
-                                    'description': 'Response driven reminder group 3 Welsh',
-                                    'dataset': 'PPD1.2'})
-
-    get_and_check_print_file(
+    decrypted_print_file = get_and_check_print_file(
         sftp=sftp_client,
         remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
         expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_3\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'Response driven reminder group 3 Welsh',
+                                    'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
 def test_our_decryption_key(sftp_client):
@@ -891,12 +891,14 @@ def get_multiple_print_and_manifest_filenames(sftp, remote_directory, pack_code,
     return matched_manifest_files, matched_print_files
 
 
-def get_and_check_manifest_file(sftp, remote_manifest_path, expected_values):
+def get_and_check_manifest_file(sftp, remote_manifest_path, expected_values, decrypted_print_file):
     with sftp.open(remote_manifest_path) as actual_manifest_file:
         manifest_json = json.loads(actual_manifest_file.read())
     for key, value in expected_values.items():
         assert manifest_json[key] == value
+    actual_row_count = len(decrypted_print_file.splitlines())
 
+    assert actual_row_count == manifest_json['files'][0]['row_count']
     assert manifest_json['files'][0]['relativePath'] == './'
     assert manifest_json['sourceName'] == 'ONS_RM'
     assert manifest_json['schemaVersion'] == '1'
@@ -923,6 +925,7 @@ def get_and_check_print_file(sftp, remote_print_file_path, decryption_key_path, 
                                                decryption_key_path,
                                                decryption_key_passphrase)
     assert decrypted_print_file == expected
+    return decrypted_print_file
 
 
 def get_and_check_multiple_print_files(sftp, remote_print_file_directory, print_files, decryption_key_path,

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -45,7 +45,7 @@ def test_processing_complete_file_uploads_correct_files(cleanup_test_files):
     with patch('app.file_sender.sftp.SftpUtility') as patched_sftp, patch('app.file_sender.datetime') as patch_datetime:
         mock_time = datetime(2019, 1, 1, 7, 6, 5)
         patch_datetime.utcnow.return_value = mock_time
-        process_complete_file(complete_file_path, PackCode.P_IC_ICL1, context_logger)
+        process_complete_file(complete_file_path, PackCode.P_IC_ICL1, context_logger, row_count=)
 
     put_sftp_call_kwargs = [kwargs for _, kwargs in
                             patched_sftp.return_value.__enter__.return_value.put_file.call_args_list]

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -45,7 +45,7 @@ def test_processing_complete_file_uploads_correct_files(cleanup_test_files):
     with patch('app.file_sender.sftp.SftpUtility') as patched_sftp, patch('app.file_sender.datetime') as patch_datetime:
         mock_time = datetime(2019, 1, 1, 7, 6, 5)
         patch_datetime.utcnow.return_value = mock_time
-        process_complete_file(complete_file_path, PackCode.P_IC_ICL1, context_logger, row_count=)
+        process_complete_file(complete_file_path, PackCode.P_IC_ICL1, context_logger)
 
     put_sftp_call_kwargs = [kwargs for _, kwargs in
                             patched_sftp.return_value.__enter__.return_value.put_file.call_args_list]
@@ -92,7 +92,7 @@ def test_local_files_are_deleted_after_upload(cleanup_test_files):
 def test_generating_manifest_file_ppd(cleanup_test_files):
     manifest_file = cleanup_test_files.encrypted_files.joinpath('P_IC_ICL1_2019-07-05T08-15-41.manifest')
     print_file = resource_file_path.joinpath('P_IC_ICL1_2019-07-05T08-15-41.csv.gpg')
-    generate_manifest_file(manifest_file, print_file, PackCode.P_IC_ICL1)
+    generate_manifest_file(manifest_file, print_file, PackCode.P_IC_ICL1, row_count=10)
 
     manifest_json = json.loads(manifest_file.read_text())
 
@@ -100,12 +100,13 @@ def test_generating_manifest_file_ppd(cleanup_test_files):
     assert manifest_json['description'] == 'Initial contact letter households - England'
     assert manifest_json['sourceName'] == 'ONS_RM'
     assert manifest_json['dataset'] == 'PPD1.1'
+    assert manifest_json['files'][0]['rows'] == 10
 
 
 def test_generating_manifest_file_qm(cleanup_test_files):
     manifest_file = cleanup_test_files.encrypted_files.joinpath('P_IC_H1_2019-07-08T11-57-11.manifest')
     print_file = resource_file_path.joinpath('P_IC_H1_2019-07-08T11-57-11.csv.gpg')
-    generate_manifest_file(manifest_file, print_file, PackCode.P_IC_H1)
+    generate_manifest_file(manifest_file, print_file, PackCode.P_IC_H1, row_count=10)
 
     manifest_json = json.loads(manifest_file.read_text())
 
@@ -113,6 +114,7 @@ def test_generating_manifest_file_qm(cleanup_test_files):
     assert manifest_json['description'] == 'Initial contact questionnaire households - England'
     assert manifest_json['sourceName'] == 'ONS_RM'
     assert manifest_json['dataset'] == 'QM3.2'
+    assert manifest_json['files'][0]['rows'] == 10
 
 
 def test_check_partial_has_no_duplicates_with_duplicates(cleanup_test_files):


### PR DESCRIPTION
# Motivation and Context
The rows count is now required on the print file manifest

# What has changed
* Add row count to print file manifest
* Update tests
* Temporarily disable pipenv check

# How to test?
Build and run against linked AT's branch

# Links
https://trello.com/c/Ole04jk0/735-add-rows-count-attribute-to-manifest-5
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/229