### PR TITLE
472 ic01 ic02 generate ce1 addressed print files

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -9,7 +9,7 @@ class ActionType(Enum):
 
     # Initial contact letter CE/SPG
     CE1_IC01 = 'CE1_IC01'
-    D_CE1A_ICLCR2B = 'D_CE1A_ICLCR2B'
+    CE1_IC02 = 'CE1_IC02'
 
     # Initial contact household questionnaires
     ICHHQE = 'ICHHQE'
@@ -58,7 +58,7 @@ class PackCode(Enum):
     P_IC_ICL4 = 'P_IC_ICL4'
 
     # Initial contact letter CE/SPG
-    CE1_IC01 = 'CE1_IC01'
+    D_CE1A_ICLCR1 = 'D_CE1A_ICLCR1'
     D_CE1A_ICLCR2B = 'D_CE1A_ICLCR2B'
 
     # Initial contact questionnaires

--- a/app/constants.py
+++ b/app/constants.py
@@ -166,7 +166,7 @@ class PrintTemplate:
                            'postcode',
                            'packCode',
                            'qid',
-                           'organizationName',
+                           'organisationName',
                            'fieldCoordinatorId',
                            'fieldOfficerId')
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -165,10 +165,10 @@ class PrintTemplate:
                            'townName',
                            'postcode',
                            'packCode',
-                           'questionnaireId',
+                           'qid',
                            'organizationName',
-                           'coordinatorId',
-                           'officerId')
+                           'fieldCoordinatorId',
+                           'fieldOfficerId')
 
     QM_QUESTIONNAIRE_TEMPLATE = ('uac',
                                  'qid',

--- a/app/constants.py
+++ b/app/constants.py
@@ -7,6 +7,10 @@ class ActionType(Enum):
     ICL2W = 'ICL2W'
     ICL4N = 'ICL4N'
 
+    # Initial contact letter CE/SPG
+    CE1_IC01 = 'CE1_IC01'
+    D_CE1A_ICLCR2B = 'D_CE1A_ICLCR2B'
+
     # Initial contact household questionnaires
     ICHHQE = 'ICHHQE'
     ICHHQW = 'ICHHQW'
@@ -52,6 +56,10 @@ class PackCode(Enum):
     P_IC_ICL1 = 'P_IC_ICL1'
     P_IC_ICL2B = 'P_IC_ICL2B'
     P_IC_ICL4 = 'P_IC_ICL4'
+
+    # Initial contact letter CE/SPG
+    CE1_IC01 = 'CE1_IC01'
+    D_CE1A_ICLCR2B = 'D_CE1A_ICLCR2B'
 
     # Initial contact questionnaires
     P_IC_H1 = 'P_IC_H1'
@@ -156,7 +164,11 @@ class PrintTemplate:
                            'addressLine3',
                            'townName',
                            'postcode',
-                           'packCode')
+                           'packCode',
+                           'questionnaireId',
+                           'organizationName',
+                           'coordinatorId',
+                           'officerId')
 
     QM_QUESTIONNAIRE_TEMPLATE = ('uac',
                                  'qid',

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -65,7 +65,7 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_RD_2RL2B_2: 'Response driven reminder group 2 Welsh',
     PackCode.P_RD_2RL1_3: 'Response driven reminder group 3 English',
     PackCode.P_RD_2RL2B_3: 'Response driven reminder group 3 Welsh',
-    PackCode.CE1_IC01: 'CE1 ICL with UAC for England (Hand Delivery) Addressed',
+    PackCode.D_CE1A_ICLCR1: 'CE1 ICL with UAC for England (Hand Delivery) Addressed',
     PackCode.D_CE1A_ICLCR2B: 'CE1 ICL with UAC for Wales (Hand Delivery) Addressed'
 }
 
@@ -132,7 +132,7 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_RD_2RL2B_2: Dataset.PPD1_2,
     PackCode.P_RD_2RL1_3: Dataset.PPD1_2,
     PackCode.P_RD_2RL2B_3: Dataset.PPD1_2,
-    PackCode.CE1_IC01: Dataset.PPD1_1,
+    PackCode.D_CE1A_ICLCR1: Dataset.PPD1_1,
     PackCode.D_CE1A_ICLCR2B: Dataset.PPD1_1
 }
 
@@ -183,7 +183,7 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.P_RD_2RL1_3: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RD_2RL2B_3: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.CE1_IC01: PrintTemplate.PPO_LETTER_TEMPLATE,
-    ActionType.D_CE1A_ICLCR2B: PrintTemplate.PPO_LETTER_TEMPLATE
+    ActionType.CE1_IC02: PrintTemplate.PPO_LETTER_TEMPLATE
 }
 
 SUPPLIER_TO_PRINT_TEMPLATE = {

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -64,7 +64,9 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_RD_2RL1_2: 'Response driven reminder group 2 English',
     PackCode.P_RD_2RL2B_2: 'Response driven reminder group 2 Welsh',
     PackCode.P_RD_2RL1_3: 'Response driven reminder group 3 English',
-    PackCode.P_RD_2RL2B_3: 'Response driven reminder group 3 Welsh'
+    PackCode.P_RD_2RL2B_3: 'Response driven reminder group 3 Welsh',
+    PackCode.CE1_IC01: 'CE1 ICL with UAC for England (Hand Delivery) Addressed',
+    PackCode.D_CE1A_ICLCR2B: 'CE1 ICL with UAC for Wales (Hand Delivery) Addressed'
 }
 
 PACK_CODE_TO_DATASET = {
@@ -129,7 +131,9 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_RD_2RL1_2: Dataset.PPD1_2,
     PackCode.P_RD_2RL2B_2: Dataset.PPD1_2,
     PackCode.P_RD_2RL1_3: Dataset.PPD1_2,
-    PackCode.P_RD_2RL2B_3: Dataset.PPD1_2
+    PackCode.P_RD_2RL2B_3: Dataset.PPD1_2,
+    PackCode.CE1_IC01: Dataset.PPD1_1,
+    PackCode.D_CE1A_ICLCR2B: Dataset.PPD1_1
 }
 
 DATASET_TO_SUPPLIER = {
@@ -178,6 +182,8 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.P_RD_2RL2B_2: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RD_2RL1_3: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RD_2RL2B_3: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.CE1_IC01: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.D_CE1A_ICLCR2B: PrintTemplate.PPO_LETTER_TEMPLATE
 }
 
 SUPPLIER_TO_PRINT_TEMPLATE = {

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -839,6 +839,58 @@ def test_P_RD_2RL2B_3(sftp_client):
                                     'dataset': 'PPD1.2'}, decrypted_print_file=decrypted_print_file)
 
 
+def test_CE1_IC01(sftp_client):
+    # Given
+    ce1_ic01_messages, _ = build_test_messages(ICL_message_template, 1, 'CE1_IC01', 'D_CE1A_ICLCR1')
+    send_action_messages(ce1_ic01_messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'D_CE1A_ICLCR1')
+
+    # Then
+    decrypted_print_file = get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR1||||\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'CE1 ICL with UAC for England (Hand Delivery) Addressed',
+                                    'dataset': 'PPD1.1'}, decrypted_print_file=decrypted_print_file)
+
+
+def test_CE1_IC02(sftp_client):
+    # Given
+    ce1_ic02_messages, _ = build_test_messages(ICL_message_template, 1, 'CE1_IC02', 'D_CE1A_ICLCR2B')
+    send_action_messages(ce1_ic02_messages)
+
+    # When
+    matched_manifest_file, matched_print_file = get_print_and_manifest_filenames(sftp_client,
+                                                                                 TestConfig.SFTP_PPO_DIRECTORY,
+                                                                                 'D_CE1A_ICLCR2B')
+
+    # Then
+    decrypted_print_file = get_and_check_print_file(
+        sftp=sftp_client,
+        remote_print_file_path=TestConfig.SFTP_PPO_DIRECTORY + matched_print_file,
+        decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
+                                                               'dummy_ppo_supplier_private_key.asc'),
+        decryption_key_passphrase='test',
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR2B||||\n')
+
+    get_and_check_manifest_file(sftp=sftp_client,
+                                remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
+                                expected_values={
+                                    'description': 'CE1 ICL with UAC for Wales (Hand Delivery) Addressed',
+                                    'dataset': 'PPD1.1'}, decrypted_print_file=decrypted_print_file)
+
+
 def test_our_decryption_key(sftp_client):
     # Given
     icl1e_messages, _ = build_test_messages(ICL_message_template, 1, 'ICL1E', 'P_IC_ICL1')

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -841,7 +841,7 @@ def test_P_RD_2RL2B_3(sftp_client):
 
 def test_CE1_IC01(sftp_client):
     # Given
-    ce1_ic01_messages, _ = build_test_messages(ICL_message_template, 1, 'CE1_IC01', 'D_CE1A_ICLCR1')
+    ce1_ic01_messages, _ = build_test_messages(ICL_message_template, 1, 'CE1_IC01', 'D_CE1A_ICLCR1', ce=True)
     send_action_messages(ce1_ic01_messages)
 
     # When
@@ -856,7 +856,8 @@ def test_CE1_IC01(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR1||||\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR1|english_qid|ONS'
+                 '|ppo_field_coordinator_id|dummy_field_officer_id\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -867,7 +868,7 @@ def test_CE1_IC01(sftp_client):
 
 def test_CE1_IC02(sftp_client):
     # Given
-    ce1_ic02_messages, _ = build_test_messages(ICL_message_template, 1, 'CE1_IC02', 'D_CE1A_ICLCR2B')
+    ce1_ic02_messages, _ = build_test_messages(ICL_message_template, 1, 'CE1_IC02', 'D_CE1A_ICLCR2B', ce=True)
     send_action_messages(ce1_ic02_messages)
 
     # When
@@ -882,7 +883,8 @@ def test_CE1_IC02(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR2B||||\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR2B|english_qid|ONS'
+                 '|ppo_field_coordinator_id|dummy_field_officer_id\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,

--- a/test/integration_tests/test_print_files.py
+++ b/test/integration_tests/test_print_files.py
@@ -30,7 +30,7 @@ def test_ICL1E(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -61,27 +61,27 @@ def test_ICL1E_split_files(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected=('0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '1|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '2|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '3|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '4|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '5|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '6|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '7|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '8|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '9|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '10|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '11|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '12|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '13|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '14|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '15|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '16|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '17|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '18|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '19|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-                  '20|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'))
+        expected=('0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '1|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '2|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '3|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '4|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '5|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '6|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '7|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '8|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '9|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '10|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '11|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '12|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '13|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '14|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '15|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '16|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '17|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '18|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '19|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+                  '20|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'))
 
 
 def test_ICL2W(sftp_client):
@@ -101,7 +101,7 @@ def test_ICL2W(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL2B\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL2B||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -127,7 +127,7 @@ def test_ICL4N(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL4\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL4||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -481,7 +481,7 @@ def test_P_RL_1RL1_1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RL_1RL1_1\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RL_1RL1_1||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -507,7 +507,7 @@ def test_P_LP_HL1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_LP_HL1\n')
+        expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_LP_HL1||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -533,7 +533,7 @@ def test_P_TB_TBPOL1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1\n')
+        expected='|test_caseref|Mr|Test|McTest|123 Fake Street|Duffryn||Newport|NPXXXX|P_TB_TBPOL1||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -700,7 +700,7 @@ def test_P_RD_2RL1_1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_1\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_1||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -726,7 +726,7 @@ def test_P_RD_2RL2B_1(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_1\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_1||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -752,7 +752,7 @@ def test_P_RD_2RL1_2(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_2\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_2||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -778,7 +778,7 @@ def test_P_RD_2RL2B_2(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_2\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_2||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -804,7 +804,7 @@ def test_P_RD_2RL1_3(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_3\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL1_3||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -830,7 +830,7 @@ def test_P_RD_2RL2B_3(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'dummy_ppo_supplier_private_key.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_3\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_RD_2RL2B_3||||\n')
 
     get_and_check_manifest_file(sftp=sftp_client,
                                 remote_manifest_path=TestConfig.SFTP_PPO_DIRECTORY + matched_manifest_file,
@@ -856,7 +856,7 @@ def test_our_decryption_key(sftp_client):
         decryption_key_path=Path(__file__).parents[2].joinpath('dummy_keys',
                                                                'our_dummy_private.asc'),
         decryption_key_passphrase='test',
-        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n')
+        expected='0|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n')
 
 
 def get_print_and_manifest_filenames(sftp, remote_directory, pack_code, max_attempts=10):

--- a/test/integration_tests/test_quarantine_files.py
+++ b/test/integration_tests/test_quarantine_files.py
@@ -23,9 +23,9 @@ def test_icl1e_with_duplicate_uacs_is_quarantined():
 
     # Then
     assert expected_quarantined_file.read_text() == (
-        'test_duplicate|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-        '1|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n'
-        'test_duplicate|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1\n')
+        'test_duplicate|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+        '1|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n'
+        'test_duplicate|test_caseref||||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n')
 
 
 def test_ichhqw_with_duplicate_uacs_is_quarantined():

--- a/test/integration_tests/utilities.py
+++ b/test/integration_tests/utilities.py
@@ -42,8 +42,8 @@ PPD1_3_message_template = {
     "townName": "Newport",
     "postcode": "NPXXXX",
     "packCode": None,
-    "questionnaireId": None,
-    "organizationName": None,
+    "qid": None,
+    "organisationName": None,
     "coordinatorId": None,
     "officerId": None
 }
@@ -107,11 +107,33 @@ def build_messages_no_uac(action_type, quantity, pack_code, batch_id, messages):
     return messages, batch_id
 
 
-def build_test_messages(message_template, quantity, action_type, pack_code, uac=True):
+def build_ce_messages(message_template, action_type, quantity, pack_code, batch_id, messages):
+    test_uac = 0
+    for message in messages:
+        message.update({'actionType': action_type,
+                        'batchQuantity': quantity,
+                        'packCode': pack_code,
+                        'batchId': batch_id,
+                        'uac': str(test_uac),
+                        'qid': 'english_qid',
+                        'fieldOfficerId': 'dummy_field_officer_id',
+                        'fieldCoordinatorId': 'ppo_field_coordinator_id',
+                        'organisationName': 'ONS'})
+        test_uac += 1
+        if 'uacWales' in message_template.keys():
+            message['uacWales'] = str(test_uac)
+            test_uac += 1
+    return messages, batch_id
+    pass
+
+
+def build_test_messages(message_template, quantity, action_type, pack_code, uac=True, ce=False):
     messages = []
     batch_id = str(uuid.uuid4())
     for _ in range(quantity):
         messages.append(message_template.copy())
+    if ce:
+        return build_ce_messages(message_template, action_type, quantity, pack_code, batch_id, messages)
     return build_messages_with_uac(message_template, action_type, quantity, pack_code, batch_id, messages) \
         if uac else build_messages_no_uac(action_type, quantity, pack_code, batch_id, messages)
 

--- a/test/integration_tests/utilities.py
+++ b/test/integration_tests/utilities.py
@@ -16,7 +16,7 @@ ICL_message_template = {
     "postcode": "NPXXXX",
     "packCode": None,
     "questionnaireId": None,
-    "organizationName": None,
+    "organisationName": None,
     "coordinatorId": None,
     "officerId": None
 }
@@ -124,7 +124,6 @@ def build_ce_messages(message_template, action_type, quantity, pack_code, batch_
             message['uacWales'] = str(test_uac)
             test_uac += 1
     return messages, batch_id
-    pass
 
 
 def build_test_messages(message_template, quantity, action_type, pack_code, uac=True, ce=False):

--- a/test/integration_tests/utilities.py
+++ b/test/integration_tests/utilities.py
@@ -14,7 +14,11 @@ ICL_message_template = {
     "addressLine2": "Duffryn",
     "townName": "Newport",
     "postcode": "NPXXXX",
-    "packCode": None
+    "packCode": None,
+    "questionnaireId": None,
+    "organizationName": None,
+    "coordinatorId": None,
+    "officerId": None
 }
 
 reminder_message_template = {
@@ -27,7 +31,6 @@ reminder_message_template = {
     "packCode": None
 }
 
-
 PPD1_3_message_template = {
     "uac": None,
     "caseRef": "test_caseref",
@@ -38,7 +41,11 @@ PPD1_3_message_template = {
     "addressLine2": "Duffryn",
     "townName": "Newport",
     "postcode": "NPXXXX",
-    "packCode": None
+    "packCode": None,
+    "questionnaireId": None,
+    "organizationName": None,
+    "coordinatorId": None,
+    "officerId": None
 }
 
 print_questionnaire_message_template = {

--- a/test/unit_tests/app/test_print_file_builder.py
+++ b/test/unit_tests/app/test_print_file_builder.py
@@ -18,7 +18,11 @@ def test_generate_print_row_valid_ICL1E(cleanup_test_files):
         "addressLine2": "Duffryn",
         "townName": "Newport",
         "postcode": "NPXXXX",
-        "packCode": "P_IC_ICL1"
+        "packCode": "P_IC_ICL1",
+        "questionnaireId": "01000000000093",
+        "organizationName": "ONS",
+        "coordinatorId": "123456789",
+        "officerId": "012345678"
     })
 
     # When
@@ -27,7 +31,8 @@ def test_generate_print_row_valid_ICL1E(cleanup_test_files):
     # Then
     generated_print_file = cleanup_test_files.partial_files.joinpath('ICL1E.P_IC_ICL1.1.3')
     assert generated_print_file.read_text() == ('test_uac|test_caseref||||123 Fake Street'
-                                                '|Duffryn||Newport|NPXXXX|P_IC_ICL1\n')
+                                                '|Duffryn||Newport|NPXXXX|P_IC_ICL1|01000000000093'
+                                                '|ONS|123456789|012345678\n')
 
 
 def test_generate_print_row_valid_ICHHQE(cleanup_test_files):

--- a/test/unit_tests/app/test_print_file_builder.py
+++ b/test/unit_tests/app/test_print_file_builder.py
@@ -19,10 +19,10 @@ def test_generate_print_row_valid_ICL1E(cleanup_test_files):
         "townName": "Newport",
         "postcode": "NPXXXX",
         "packCode": "P_IC_ICL1",
-        "questionnaireId": "01000000000093",
-        "organizationName": "ONS",
-        "coordinatorId": "123456789",
-        "officerId": "012345678"
+        "qid": "",
+        "organisationName": "",
+        "fieldCoordinatorId": "",
+        "fieldOfficerId": ""
     })
 
     # When
@@ -31,8 +31,7 @@ def test_generate_print_row_valid_ICL1E(cleanup_test_files):
     # Then
     generated_print_file = cleanup_test_files.partial_files.joinpath('ICL1E.P_IC_ICL1.1.3')
     assert generated_print_file.read_text() == ('test_uac|test_caseref||||123 Fake Street'
-                                                '|Duffryn||Newport|NPXXXX|P_IC_ICL1|01000000000093'
-                                                '|ONS|123456789|012345678\n')
+                                                '|Duffryn||Newport|NPXXXX|P_IC_ICL1||||\n')
 
 
 def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
@@ -62,6 +61,35 @@ def test_generate_print_row_valid_ICHHQE(cleanup_test_files):
     assert generated_print_file.read_text() == (
         'test_uac|test_qid|test_wales_uac|test_wales_qid|test_qm_coordinator_id|'
         '|||123 Fake Street|Duffryn||Newport|NPXXXX|P_IC_H1\n')
+
+
+def test_generate_print_row_valid_CE1_IC01(cleanup_test_files):
+    # Given
+    json_body = json.dumps({
+        "actionType": "CE1_IC01",
+        "batchId": "1",
+        "batchQuantity": 3,
+        "uac": "test_uac",
+        "caseRef": "test_caseref",
+        "addressLine1": "123 Fake Street",
+        "addressLine2": "Duffryn",
+        "townName": "Newport",
+        "postcode": "NPXXXX",
+        "packCode": "D_CE1A_ICLCR1",
+        "qid": "31000000000093",
+        "organisationName": "ONS",
+        "fieldCoordinatorId": "123456789",
+        "fieldOfficerId": "012345678"
+    })
+
+    # When
+    generate_print_row(json_body, cleanup_test_files.partial_files)
+
+    # Then
+    generated_print_file = cleanup_test_files.partial_files.joinpath('CE1_IC01.D_CE1A_ICLCR1.1.3')
+    assert generated_print_file.read_text() == ('test_uac|test_caseref||||123 Fake Street'
+                                                '|Duffryn||Newport|NPXXXX|D_CE1A_ICLCR1|31000000000093'
+                                                '|ONS|123456789|012345678\n')
 
 
 def test_generate_print_row_invalid_action_type(cleanup_test_files):


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To be able to generate ce1 print files, we need to add the new mappings for the pack codes and action types. Theres also 4 new fields to be added.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added CE1 action types/pack codes
- Added 4 new fields to the PPO template

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run `make build_and_test` and everything should pass.
- Run with other PRs on ticket and run the ATs 
[Action-worker](https://github.com/ONSdigital/census-rm-action-worker/pull/19)
[Action-scheduler](https://github.com/ONSdigital/census-rm-action-scheduler/pull/76)
[Acceptance tests](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/234)

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/H1lzyyIr)