### PR TITLE
Persist quarantined messages

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,8 +16,6 @@ class Config:
     RABBIT_USERNAME = os.getenv('RABBIT_USERNAME')
     RABBIT_PASSWORD = os.getenv('RABBIT_PASSWORD')
     RABBIT_ROUTING_KEY = os.getenv('RABBIT_ROUTING_KEY', 'Action.Printer.binding')
-    RABBIT_QUARANTINE_QUEUE = os.getenv('RABBIT_QUARANTINE_QUEUE', 'quarantineQueue')
-    RABBIT_QUARANTINE_EXCHANGE = os.getenv('RABBIT_QUARANTINE_QUEUE', 'quarantineExchange')
 
     PARTIAL_FILES_DIRECTORY = Path(os.getenv('PARTIAL_FILES_DIRECTORY', 'partial_files/'))
     ENCRYPTED_FILES_DIRECTORY = Path(os.getenv('ENCRYPTED_FILES_DIRECTORY', 'encrypted_files/'))


### PR DESCRIPTION
# Motivation and Context
For speed of development during the rehearsal, we didn't make the Exception Manager persistent. We now need to have the service backed by a persistent data store instead of using a Rabbit queue to save the quarantined messages.

# What has changed
Added persistence.

# How to test?
Publish a bad message onto a Rabbit queue. Quarantine the bad message. Check the `exceptionmanager` database.

# Links
Trello: https://trello.com/c/sYuR2Vgw