### PR TITLE
Add additional paper UAC fulfilment mappings

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -94,6 +94,9 @@ class ActionType(Enum):
     # Household Unique Access Codes via paper
     P_UAC_HX = 'P_UAC_HX'
 
+    # UAC provided to CE manager via paper
+    P_UAC_CX = 'P_UAC_CX'
+
     # Information leaflet
     P_ER_IL = 'P_ER_IL'
 
@@ -168,6 +171,9 @@ class PackCode(Enum):
     P_UAC_UACIP1 = 'P_UAC_UACIP1'
     P_UAC_UACIP2B = 'P_UAC_UACIP2B'
     P_UAC_UACIP4 = 'P_UAC_UACIP4'
+    P_UAC_UACIPA1 = 'P_UAC_UACIPA1'
+    P_UAC_UACIPA2B = 'P_UAC_UACIPA2B'
+    P_UAC_UACIPA4 = 'P_UAC_UACIPA4'
 
     # Large print Household questionnaire fulfilments
     P_LP_HL1 = "P_LP_HL1"
@@ -290,6 +296,10 @@ class PackCode(Enum):
     P_UAC_UACHHP1 = 'P_UAC_UACHHP1'
     P_UAC_UACHHP2B = 'P_UAC_UACHHP2B'
     P_UAC_UACHHP4 = 'P_UAC_UACHHP4'
+
+    # UAC provided to CE manager via paper
+    P_UAC_UACCEP1 = 'P_UAC_UACCEP1'
+    P_UAC_UACCEP2B = 'P_UAC_UACCEP2B'
 
     # Information leaflet
     P_ER_ILER1 = 'P_ER_ILER1'

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -175,7 +175,14 @@ PACK_CODE_TO_DESCRIPTION = {
 
     PackCode.P_UAC_UACIP1: 'Individual Unique Access Code for England via paper',
     PackCode.P_UAC_UACIP2B: 'Individual Unique Access Code for Wales (English/Welsh - Bilingual) via paper',
-    PackCode.P_UAC_UACIP4: 'Individual Unique Access Code for Northern Ireland via paper'
+    PackCode.P_UAC_UACIP4: 'Individual Unique Access Code for Northern Ireland via paper',
+    PackCode.P_UAC_UACIPA1: 'Individual Unique Access Code for England via paper - Request from EQ',
+    PackCode.P_UAC_UACIPA2B: 'Individual Unique Access Code for Wales (English/Welsh - Bilingual) via paper - Request'
+                             ' from EQ',
+    PackCode.P_UAC_UACIPA4: 'Individual Unique Access Code for Northern Ireland via paper - Request from EQ',
+
+    PackCode.P_UAC_UACCEP1: 'UAC provided to Communal Establishment manager in England via paper',
+    PackCode.P_UAC_UACCEP2B: 'UAC provided to Communal Establishment manager in Wales via paper (Bilingual)'
 }
 
 PACK_CODE_TO_DATASET = {
@@ -347,6 +354,11 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_UAC_UACIP1: Dataset.PPD1_3,
     PackCode.P_UAC_UACIP2B: Dataset.PPD1_3,
     PackCode.P_UAC_UACIP4: Dataset.PPD1_3,
+    PackCode.P_UAC_UACIPA1: Dataset.PPD1_3,
+    PackCode.P_UAC_UACIPA2B: Dataset.PPD1_3,
+    PackCode.P_UAC_UACIPA4: Dataset.PPD1_3,
+    PackCode.P_UAC_UACCEP1: Dataset.PPD1_3,
+    PackCode.P_UAC_UACCEP2B: Dataset.PPD1_3,
 }
 
 DATASET_TO_SUPPLIER = {
@@ -431,6 +443,7 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.P_ER_IL: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_UAC_IX: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_OR_HX: PrintTemplate.QM_QUESTIONNAIRE_TEMPLATE,
+    ActionType.P_UAC_CX: PrintTemplate.PPO_LETTER_TEMPLATE,
 }
 
 SUPPLIER_TO_PRINT_TEMPLATE = {


### PR DESCRIPTION
# Motivation and Context
Additional paper fulfillments.  See https://collaborate2.ons.gov.uk/confluence/display/SDC/RM+Product+Library - rows 35-37, 41-42.

# What has changed
New fulfilment codes and questionnaire type mappings

# How to test?
Run the `additional-paper-uac-fulfilments` branch of acceptance tests against this branch and the equivalent branches of case-processor, action-processor, action-scheduler and printfile service.

# Links
https://trello.com/c/TRqlAbsI