### PR TITLE
BUG: Don't sort already sorted files

### DIFF
--- a/app/print_file_sorter.py
+++ b/app/print_file_sorter.py
@@ -10,7 +10,8 @@ from config import Config
 
 def sort_print_file_if_required(complete_partial_file: Path, pack_code: PackCode, action_type: ActionType,
                                 context_logger):
-    if pack_code in PrintFileSorting.PACKCODES_TO_SORT:
+    # We only need to sort a subset of packcodes and we don't want to try to sort an already sorted file
+    if pack_code in PrintFileSorting.PACKCODES_TO_SORT and not complete_partial_file.name.endswith('.sorted'):
         file_to_sort = copy_file_to_sorting_dir_to_sort(complete_partial_file)
         print_template = ACTION_TYPE_TO_PRINT_TEMPLATE[action_type]
         sorting_key_indexed = get_column_indexes_by_name_from_template(print_template, PrintFileSorting.SORTING_KEY)

--- a/test/resources/CE_IC08.D_FDCE_I4.1.10
+++ b/test/resources/CE_IC08.D_FDCE_I4.1.10
@@ -1,0 +1,10 @@
+test_uac2|test_caseref2||2 Fake Street|Duffryn2||Newport2|NPXXXX2|P_IC_ICL1|blah|blah|blah|a|org2|blah|02
+test_uac9|test_caseref9||9 Fake Street|Duffryn9||Newport9|NPXXXX9|P_IC_ICL1|blah|blah|blah|a|org2|blah|09
+test_uac1|test_caseref1||1 Fake Street|Duffryn1||Newport1|NPXXXX1|P_IC_ICL1|blah|blah|blah|a|org1|blah|01
+test_uac6|test_caseref6||6 Fake Street|Duffryn6||Newport6|NPXXXX6|P_IC_ICL1|blah|blah|blah|a|org6|blah|06
+test_uac4|test_caseref4||4 Fake Street|Duffryn4||Newport4|NPXXXX4|P_IC_ICL1|blah|blah|blah|a|org4|blah|04
+test_uac10|test_caseref10||10 Fake Street|Duffryn10||Newport10|NPXXXX10|P_IC_ICL1|blah|blah|blah|a|org0|blah|10
+test_uac5|test_caseref5||5 Fake Street|Duffryn5||Newport5|NPXXXX5|P_IC_ICL1|blah|blah|blah|a|org5|blah|05
+test_uac8|test_caseref8||8 Fake Street|Duffryn8||Newport8|NPXXXX8|P_IC_ICL1|blah|blah|blah|a|org8|blah|08
+test_uac7|test_caseref7||7 Fake Street|Duffryn7||Newport7|NPXXXX7|P_IC_ICL1|blah|blah|blah|a|org7|blah|07
+test_uac3|test_caseref3||3 Fake Street|Duffryn3||Newport3|NPXXXX3|P_IC_ICL1|blah|blah|blah|a|org2|blah|03

--- a/test/resources/CE_IC08.D_FDCE_I4.1.10.sorted
+++ b/test/resources/CE_IC08.D_FDCE_I4.1.10.sorted
@@ -1,0 +1,10 @@
+test_uac1|test_caseref1||1 Fake Street|Duffryn1||Newport1|NPXXXX1|P_IC_ICL1|blah|blah|blah|a|org1|blah|01
+test_uac2|test_caseref2||2 Fake Street|Duffryn2||Newport2|NPXXXX2|P_IC_ICL1|blah|blah|blah|a|org2|blah|02
+test_uac3|test_caseref3||3 Fake Street|Duffryn3||Newport3|NPXXXX3|P_IC_ICL1|blah|blah|blah|a|org2|blah|03
+test_uac4|test_caseref4||4 Fake Street|Duffryn4||Newport4|NPXXXX4|P_IC_ICL1|blah|blah|blah|a|org4|blah|04
+test_uac5|test_caseref5||5 Fake Street|Duffryn5||Newport5|NPXXXX5|P_IC_ICL1|blah|blah|blah|a|org5|blah|05
+test_uac6|test_caseref6||6 Fake Street|Duffryn6||Newport6|NPXXXX6|P_IC_ICL1|blah|blah|blah|a|org6|blah|06
+test_uac7|test_caseref7||7 Fake Street|Duffryn7||Newport7|NPXXXX7|P_IC_ICL1|blah|blah|blah|a|org7|blah|07
+test_uac8|test_caseref8||8 Fake Street|Duffryn8||Newport8|NPXXXX8|P_IC_ICL1|blah|blah|blah|a|org8|blah|08
+test_uac9|test_caseref9||9 Fake Street|Duffryn9||Newport9|NPXXXX9|P_IC_ICL1|blah|blah|blah|a|org2|blah|09
+test_uac10|test_caseref10||10 Fake Street|Duffryn10||Newport10|NPXXXX10|P_IC_ICL1|blah|blah|blah|a|org0|blah|10


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- [x] Updated ops tool with any new scheduled action types?
We saw a bug where failed uploads attempts are not handled properly if the file it sorted, it repeatedly appended `.sorted` to the partial file resulting in it then erroring on the file because it breaks the naming system.

# What has changed
* Fix sorting to only sort a file once
* Add tests

# How to test?
Build and run tests. Check the tests are valid to prove this bug is fixed.

# Links
https://trello.com/c/AMomtv2W/1444-bug-print-file-service-doesnt-handle-failed-uploads-of-sorted-files