### PR TITLE
Add response-driven reminder pack code mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	pipenv install --dev
 
 check:
-	# TODO: 38932 - Explicitly ignore (unused) cryptography package warning for now
+	# TODO: 38932 - Explicitly ignore RSA decryption warning (unused by this service)
 	PIPENV_PYUP_API_KEY="" pipenv check -i 38932
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ install:
 	pipenv install --dev
 
 check:
-	PIPENV_PYUP_API_KEY="" pipenv check
+	# TODO: explicity ignore (unused) cryptography package warning for now
+	PIPENV_PYUP_API_KEY="" pipenv check -i 38932
 
 lint:
 	pipenv run flake8

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	pipenv install --dev
 
 check:
-	# TODO: explicity ignore (unused) cryptography package warning for now
+	# TODO: 38932 - explicity ignore (unused) cryptography package warning for now
 	PIPENV_PYUP_API_KEY="" pipenv check -i 38932
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	pipenv install --dev
 
 check:
-	# TODO: 38932 - explicity ignore (unused) cryptography package warning for now
+	# TODO: 38932 - Explicitly ignore (unused) cryptography package warning for now
 	PIPENV_PYUP_API_KEY="" pipenv check -i 38932
 
 lint:

--- a/app/constants.py
+++ b/app/constants.py
@@ -75,6 +75,12 @@ class ActionType(Enum):
     P_QU_H2 = 'P_QU_H2'
     P_QU_H4 = 'P_QU_H4'
 
+    # Response-driven reminders (by LSOA)
+    P_RD_RNP41 = 'P_RD_RNP41'
+    P_RD_RNP42B = 'P_RD_RNP42B'
+    P_RD_RNP51 = 'P_RD_RNP51'
+    P_RD_RNP52B = 'P_RD_RNP52B'
+
     # Response driven reminders, for RH launched surveys
     P_RL_1RL1A = 'P_RL_1RL1A'
     P_RL_1RL2BA = 'P_RL_1RL2BA'
@@ -149,6 +155,12 @@ class PackCode(Enum):
     P_QU_H1 = "P_QU_H1"
     P_QU_H2 = "P_QU_H2"
     P_QU_H4 = "P_QU_H4"
+
+    # Response-driven reminders (by LSOA)
+    P_RD_RNP41 = 'P_RD_RNP41'
+    P_RD_RNP42B = 'P_RD_RNP42B'
+    P_RD_RNP51 = 'P_RD_RNP51'
+    P_RD_RNP52B = 'P_RD_RNP52B'
 
     # On request questionnaire fulfilments
     P_OR_H1 = 'P_OR_H1'

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -33,6 +33,11 @@ PACK_CODE_TO_DESCRIPTION = {
     PackCode.P_RL_3RL1: 'R3 - England   Third reminder letter going to anyone except those getting RP1/2/3',
     PackCode.P_RL_3RL2B: 'R3 - Wales   Third reminder letter going to anyone except those getting RP1/2/3',
 
+    PackCode.P_RD_RNP41: 'RDR1 - England   Response-driven reminder 1 going to worst performing areas',
+    PackCode.P_RD_RNP42B: 'RDR1 - Wales   Response-driven reminder 1 going to worst performing areas',
+    PackCode.P_RD_RNP51: 'RDR2 - England   Response-driven reminder 2 going to worst performing areas',
+    PackCode.P_RD_RNP52B: 'RDR2 - Wales   Response-driven reminder 2 going to worst performing areas',
+
     PackCode.P_RL_1RL1A: 'RU1 England- First reminder going to those who have launched EQ',
     PackCode.P_RL_1RL2BA: 'RU1 Wales- First reminder going to those who have launched EQ',
     PackCode.P_RL_2RL1A: 'RU2 England- First reminder going to those who have launched EQ',
@@ -212,6 +217,11 @@ PACK_CODE_TO_DATASET = {
     PackCode.P_RL_2RL4: Dataset.PPD1_2,
     PackCode.P_RL_3RL1: Dataset.PPD1_2,
     PackCode.P_RL_3RL2B: Dataset.PPD1_2,
+
+    PackCode.P_RD_RNP41: Dataset.PPD1_2,
+    PackCode.P_RD_RNP42B: Dataset.PPD1_2,
+    PackCode.P_RD_RNP51: Dataset.PPD1_2,
+    PackCode.P_RD_RNP52B: Dataset.PPD1_2,
 
     PackCode.P_RL_1RL1B: Dataset.PPD1_2,
     PackCode.P_RL_1RL2BB: Dataset.PPD1_2,
@@ -400,6 +410,11 @@ ACTION_TYPE_TO_PRINT_TEMPLATE = {
     ActionType.P_RL_2RL2B: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RL_3RL1: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RL_3RL2B: PrintTemplate.PPO_LETTER_TEMPLATE,
+
+    ActionType.P_RD_RNP41: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_RNP42B: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_RNP51: PrintTemplate.PPO_LETTER_TEMPLATE,
+    ActionType.P_RD_RNP52B: PrintTemplate.PPO_LETTER_TEMPLATE,
 
     ActionType.P_RL_1RL1B: PrintTemplate.PPO_LETTER_TEMPLATE,
     ActionType.P_RL_1RL2BB: PrintTemplate.PPO_LETTER_TEMPLATE,


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- [x] Updated ops tool with any new scheduled action types?
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
RM will be given lists of LSOAs to generate response-driven reminders for. This PR adds new action types / pack codes.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Added new pack codes
* Explicitly ignore (unused) cryptography package warning for now. We will need to update the package at some point so will raise a ticket for this.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See Toolbox PR

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/tRiFtYj5/984-reminders-response-driven-8