### PR TITLE
Fix missing log context

### DIFF
--- a/app/file_sender.py
+++ b/app/file_sender.py
@@ -33,7 +33,7 @@ def process_complete_file(complete_partial_file: Path, pack_code: PackCode, acti
     context_logger.info('Sending files to SFTP', file_paths=list(map(str, temporary_files_paths)))
 
     try:
-        copy_files_to_sftp(temporary_files_paths, SUPPLIER_TO_SFTP_DIRECTORY[supplier])
+        copy_files_to_sftp(temporary_files_paths, SUPPLIER_TO_SFTP_DIRECTORY[supplier], context_logger)
     except Exception as ex:
         context_logger.error('Failed to send files to SFTP', file_paths=list(map(str, temporary_files_paths)))
         context_logger.warn('Deleting failed encrypted and manifest print files',
@@ -45,7 +45,7 @@ def process_complete_file(complete_partial_file: Path, pack_code: PackCode, acti
     context_logger.info('Deleting partial files', file_paths=list(map(str, [complete_partial_file])))
     delete_local_files([complete_partial_file])
 
-    upload_files_to_bucket(manifest_file, encrypted_print_file)
+    upload_files_to_bucket(manifest_file, encrypted_print_file, context_logger)
 
     context_logger.info('Deleting temporary files', file_paths=list(map(str, temporary_files_paths)))
     delete_local_files(temporary_files_paths)
@@ -193,22 +193,22 @@ def check_gcp_bucket_ready():
     logger.info('Successfully got print file bucket', bucket_name=Config.SENT_PRINT_FILE_BUCKET)
 
 
-def copy_files_to_sftp(file_paths: Collection[Path], remote_directory):
+def copy_files_to_sftp(file_paths: Collection[Path], remote_directory, context_logger):
     with sftp.SftpUtility(remote_directory) as sftp_client:
-        logger.info('Copying files to SFTP remote', sftp_directory=sftp_client.sftp_directory)
+        context_logger.info('Copying files to SFTP remote', sftp_directory=sftp_client.sftp_directory)
         for file_path in file_paths:
             sftp_client.put_file(local_path=str(file_path), filename=file_path.name)
 
-        logger.info(f'All {len(file_paths)} files successfully written to SFTP remote',
-                    sftp_directory=sftp_client.sftp_directory)
+        context_logger.info(f'All {len(file_paths)} files successfully written to SFTP remote',
+                            sftp_directory=sftp_client.sftp_directory)
 
 
-def upload_files_to_bucket(manifest_file, encrypted_print_file):
+def upload_files_to_bucket(manifest_file, encrypted_print_file, context_logger):
     if not Config.SENT_PRINT_FILE_BUCKET:
-        logger.warn('SENT_PRINT_FILE_BUCKET set to empty, skipping uploading files to GCP')
+        context_logger.warn('SENT_PRINT_FILE_BUCKET set to empty, skipping uploading files to GCP')
         return
 
-    logger.info('Copying files to GCP Bucket', sent_print_files_bucket=Config.SENT_PRINT_FILE_BUCKET)
+    context_logger.info('Copying files to GCP Bucket', sent_print_files_bucket=Config.SENT_PRINT_FILE_BUCKET)
 
     write_file_to_bucket(manifest_file)
     write_file_to_bucket(encrypted_print_file)

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -326,6 +326,7 @@ def test_failing_write_to_gcp_bucket_is_handled():
         except Exception:
             assert False, "Exception msgs from writing to GCP bucket should be handled"
 
+
 def test_write_to_gcp_bucket():
     # Given
     test_printfile = Path('test1')

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -318,13 +318,13 @@ def test_split_file_too_small(cleanup_test_files):
 def test_failing_write_to_gcp_bucket_is_handled():
     # When
     with patch('app.file_sender.storage.Client') as bucket_client:
+        # Simulate an error from the GCS storage client
         bucket_client.side_effect = exceptions.GoogleCloudError("bucket doesn't exist")
 
         try:
-            write_file_to_bucket(None)
+            write_file_to_bucket(RESOURCE_FILE_PATH.joinpath('dummy_print_file.txt'))
         except Exception:
             assert False, "Exception msgs from writing to GCP bucket should be handled"
-
 
 def test_write_to_gcp_bucket():
     # Given
@@ -380,4 +380,4 @@ def test_failing_check_of_gcp_bucket_is_handled():
         try:
             check_gcp_bucket_ready()
         except Exception:
-            assert False, "Exception msgs from writing to GCP bucket should be handled"
+            assert False, "Exception msgs when checking GCP bucket should be handled"

--- a/test/unit_tests/app/test_file_sender.py
+++ b/test/unit_tests/app/test_file_sender.py
@@ -23,12 +23,13 @@ def test_copy_files_to_sftp():
     test_files = [Path('test1'), Path('test2'), Path('test3')]
     os.environ['SFTP_DIRECTORY'] = 'test_path'
     mock_storage_client = Mock()
+    context_logger = Mock()
 
     # When
     with patch('app.file_sender.sftp.paramiko.SSHClient') as client:
         client.return_value.open_sftp.return_value = mock_storage_client  # mock the sftp client connection
         mock_storage_client.stat.return_value.st_mode = paramiko.sftp_client.stat.S_IFDIR  # mock directory exists
-        copy_files_to_sftp(test_files, 'testdir')
+        copy_files_to_sftp(test_files, 'testdir', context_logger)
 
     mock_put_file = mock_storage_client.put
 
@@ -331,6 +332,7 @@ def test_write_to_gcp_bucket():
     test_manifest_file = Path('test2')
     mock_storage_client = Mock()
     mock_bucket = Mock()
+    context_logger = Mock()
 
     # When
     with patch('app.file_sender.storage') as google_storage, \
@@ -339,7 +341,7 @@ def test_write_to_gcp_bucket():
         google_storage.Client.return_value = mock_storage_client  # mock the cloud client
         mock_storage_client.get_bucket.return_value = mock_bucket
 
-        upload_files_to_bucket(test_printfile, test_manifest_file)
+        upload_files_to_bucket(test_printfile, test_manifest_file, context_logger)
 
     mock_write_file = mock_bucket.blob
 


### PR DESCRIPTION
# Motivation and Context
The log line confirming file upload to SFTP was missing context, passing in and using the context logger automatically includes the batch ID, action type, pack code and batch quantity in that log line. Also adds in the file names to make it easier to chase down the exact files.

# What has changed
* Use context logger when uploading to SFTP and GCS

# How to test?
Check the code, check the logs when it's run, it should now include the critical context information in the log line.

# Links
https://trello.com/c/bz8vZzal/2022-fix-missing-log-context-in-print-file-service